### PR TITLE
修复暗色模式文本框显示，并支持代理启用/禁用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# Local runtime / secrets
+logs/
+*.log
+
+# Docker local overrides (Compose auto-merges this with docker-compose.yml)
+docker-compose.override.yml
+docker-compose.local.yml
+
+# IDE / OS
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store
+Thumbs.db
+
+# Claude / local worktrees
+.claude/worktrees/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+ProxyCat is a local proxy-pool middleware. Client tools point at ProxyCat’s fixed local HTTP/SOCKS5 port; ProxyCat forwards traffic through a rotating set of short-lived upstream proxies (file list or API-fetched). It is not a system-wide VPN — only traffic sent to its listen port is proxied.
+
+Current version string: `ProxyCat-V2.0.4` (hardcoded in `modules/modules.py` and `app.py`).
+
+Python target: **3.8–3.11** (docs recommend **3.11**). No test suite, linter config, or CI is present in this repo.
+
+## Common commands
+
+```bash
+# Install deps (from repo root)
+pip install -r requirements.txt
+# optional mirror:
+pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple/
+
+# CLI-only proxy server (no Web UI)
+python ProxyCat.py
+python ProxyCat.py -c config/config.ini
+
+# Recommended: Web UI + proxy (Flask on web_port, proxy on port)
+python app.py
+
+# Docker (exposes 1080 proxy + 5000 web; mounts ./config)
+docker-compose up -d --build
+docker-compose down
+docker-compose up -d
+docker logs proxycat
+```
+
+There are no unit/integration tests to run. Manual checks: start `app.py`, hit `http://127.0.0.1:5000/web?token=<token>`, send HTTP/SOCKS5 traffic through `port` (default 1080).
+
+## Architecture
+
+### Entry points
+
+| Entry | Role |
+|-------|------|
+| `app.py` | Primary runtime (also Docker `CMD`). Starts Flask web panel and runs `AsyncProxyServer` in a daemon thread via `ProxyCat.run_server`. |
+| `ProxyCat.py` | CLI runtime: loads config, optional startup proxy check, status/progress thread, then `asyncio.run(run_server(server))`. Exports `run_server` used by `app.py`. Contains a largely unused legacy `ProxyCat` class; real proxying is `AsyncProxyServer`. |
+
+### Core components
+
+```
+Client tools  -->  :port (HTTP + SOCKS5 multiplex)  -->  AsyncProxyServer
+                                                              |
+                                                    current_proxy (upstream)
+                                                              |
+                                         config/ip.txt  OR  config/getip.py (API)
+```
+
+- **`modules/proxyserver.py`** — `AsyncProxyServer` (main engine, ~1.5k lines). Single listen socket on `0.0.0.0:port`. First byte discriminates SOCKS5 (`0x05`) vs HTTP. Handles CONNECT tunneling, plain HTTP proxying, client Basic auth (`[Users]`), IP white/black lists, upstream proxy selection, failure detection, cooldowns, and connection/client pools.
+- **`modules/modules.py`** — shared helpers: bilingual `MESSAGES` / `get_message`, `load_config` / `DEFAULT_CONFIG`, proxy validity checks (`check_http_proxy` / `check_socks_proxy` / `check_proxies`), banner, version check against `https://y.shironekosan.cn/1.html`.
+- **`config/getip.py`** — `newip()`: when `use_getip=true`, fetches one `IP:PORT` from `getip_url`, optionally auto-whitelists with a vendor API, returns `socks5://[user:pass@]host:port`. Customize this file if the provider response format differs.
+- **`config/config.ini`** — all runtime knobs under `[Server]`; multi-user client credentials under `[Users]`.
+- **`config/ip.txt`** — upstream proxy list when not using GetIP (`scheme://[user:pass@]host:port`, `#` comments allowed).
+- **`config/whitelist.txt` / `blacklist.txt`** — client source IP allow/deny.
+- **`web/templates/index.html` + `web/static/`** — single-page Web admin (Bootstrap/jQuery). No separate frontend build step.
+- **`logs/proxycat.log`** — file log when running via `app.py` (also in-memory ring buffer for `/api/logs`).
+
+### Config hot-reload
+
+- CLI path (`ProxyCat.update_status`): polls mtime of `config/config.ini` and the proxy file; reloads without process restart (port changes still need a service restart to rebind).
+- Web path: POST APIs write files and call `server._init_config_values` / `_handle_mode_change` / list reloads in-process.
+
+Docker image removes baked-in `config/config.ini` at build time; runtime config must come from the mounted `./config` volume.
+
+### Proxy rotation model
+
+Modes (`mode` in config):
+
+- **`cycle`** — walk the list on a timer (`interval` seconds). Timer only advances meaningfully with traffic; switch happens when a request needs a proxy and the interval has elapsed (resource-saving design).
+- **`loadbalance`** — pick next proxy per request path; no countdown (`time_until_next_switch` is `inf`).
+- **`interval = 0`** — effectively change IP on each request (cycle path).
+
+Switch triggers (as of changelog): interval expiry, upstream failure auto-switch, Web manual switch (`/api/switch_proxy`), GetIP mode first request (lazy fetch — startup does not burn API quota).
+
+Concurrency guards: `switching_proxy` flag, `switch_cooldown` (~5s), `proxy_failure_cooldown` (~3s), `proxy_failure_lock`.
+
+Upstream formats: `http://`, `https://`, `socks5://`, with optional `user:pass@`.
+
+### Auth layers
+
+1. **Client → ProxyCat**: optional Basic auth from `[Users]`; empty section = open proxy. Also IP white/black lists with `ip_auth_priority` (`whitelist` or `blacklist`).
+2. **ProxyCat → upstream**: credentials embedded in proxy URL or `proxy_username` / `proxy_password` (GetIP path).
+3. **Web panel**: query `token` matching `Server.token` (empty token disables check). URL form: `/web?token=...`.
+
+### Web API surface (`app.py`)
+
+Notable routes (many gated by `@require_token`): `/api/status`, `/api/config`, `/api/proxies`, `/api/check_proxies`, `/api/ip_lists`, `/api/logs`, `/api/logs/clear`, `/api/switch_proxy`, `/api/service` (start/stop/restart), `/api/language`, `/api/version`, `/api/users`.
+
+Service control starts/stops the asyncio proxy loop on a background thread; Flask stays up.
+
+### i18n
+
+All user-facing strings go through `get_message(key, lang, *args)` with `language` = `cn` | `en` from config. When adding messages, add both keys under `MESSAGES` in `modules/modules.py` (and any Web UI copy that mirrors them in `index.html`).
+
+## Important behavioral constraints
+
+- GetIP API must return a single `IP:PORT` line; non-conforming providers need edits in `config/getip.py`.
+- Default listen: proxy **1080**, web **5000**.
+- `check_proxies` can be disabled to avoid aggressive switching when validity probes are noisy or blocked.
+- Failure handling should distinguish **upstream proxy death** from **destination site errors** (historical bug source — see `ProxyCat-Manual/logs.md`).
+- Run processes from the **repo root** so relative paths (`config/…`, `web/…`, `logs/…`) resolve correctly.
+
+## Docs in-repo
+
+- `README.md` / `README-EN.md` — product overview
+- `ProxyCat-Manual/Operation Manual.md` — install, config field reference, Docker, Web panel
+- `ProxyCat-Manual/Investigation Manual.md` — troubleshooting
+- `ProxyCat-Manual/logs.md` — changelog / known fix history

--- a/ProxyCat-Manual/Operation Manual.md
+++ b/ProxyCat-Manual/Operation Manual.md
@@ -139,6 +139,23 @@ proxy_file = ip.txt
 # Whether to enable proxy detection feature True or False (default:True)
 check_proxies = True
 
+# 代理连通性检测总超时（毫秒），超过即视为失败(默认为:2000)
+# Total connectivity-check deadline in milliseconds (default:2000)
+proxy_check_timeout_ms = 2000
+
+# 是否启用自动检测 True or False(默认为:false)
+# Whether to enable periodic automatic proxy checks (default:false)
+auto_check_enabled = false
+
+# 自动检测周期（分钟），仅自动检测启用时生效(默认为:60)
+# Automatic proxy check interval in minutes (default:60)
+auto_check_interval_minutes = 60
+
+# 是否自动禁用检测失败/超时的代理 True or False(默认为:false)
+# Whether to automatically disable proxies that fail or time out (default:false)
+# 启用后，手动检测和自动检测中的失败项会被写入代理列表并标记为禁用（# 前缀）
+auto_disable_failed_proxies = false
+
 # 语言设置 (cn/en)
 # Language setting (cn/en)
 language = cn

--- a/ProxyCat-Manual/Operation Manual.md
+++ b/ProxyCat-Manual/Operation Manual.md
@@ -87,7 +87,10 @@ docker-compose down | docker-compose up -d
 # 查看日志信息
 docker logs proxycat
 
-# docker端口默认为1080和5000,1080为监听端口，5000为web页面管理如需其他端口请对应修改并放行
+# docker端口默认为1080和5000,1080为监听端口，5000为web页面管理
+# 如需改端口/额外挂载等，请复制 docker-compose.override.yml.example
+# 为 docker-compose.override.yml 后修改（该文件不会被 git pull 覆盖）
+# cp docker-compose.override.yml.example docker-compose.override.yml
 ```
 
 ### 配置文件介绍

--- a/README-EN.md
+++ b/README-EN.md
@@ -51,9 +51,21 @@ Therefore, **ProxyCat** was born! This tool aims to transform short-term IPs (la
 
 ## Updating Code (Important for Docker Users)
 
-When deploying with Docker, the `config/` directory and `docker-compose.yml` contain your personal settings.
+When deploying with Docker, the `config/` directory holds your personal settings (mounted as a volume).
 
-Before running `git pull`, back them up. After pulling, restore them to avoid being overwritten:
+### Recommended: put local changes in an override file
+
+Keep the repo's `docker-compose.yml` as the base template. **Do not edit it directly.** Put port mappings, extra mounts, image names, etc. into:
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+# edit docker-compose.override.yml
+```
+
+Compose automatically merges `docker-compose.yml` + `docker-compose.override.yml`.  
+`docker-compose.override.yml` is gitignored, so `git pull` will **not** overwrite your local changes.
+
+### Legacy backup flow (if you still edit docker-compose.yml)
 
 ```bash
 # 1. Backup
@@ -63,9 +75,11 @@ cp -r config docker-compose.yml backup.bak/
 # 2. Pull latest code
 git pull
 
-# 3. Restore your config
+# 3. Restore (prefer migrating to override)
 cp -r backup.bak/config ./
-cp backup.bak/docker-compose.yml ./
+cp backup.bak/docker-compose.yml docker-compose.override.yml
+# or keep overwriting:
+# cp backup.bak/docker-compose.yml ./
 ```
 
 After restoring, rebuild and restart:

--- a/README-EN.md
+++ b/README-EN.md
@@ -49,6 +49,32 @@ Therefore, **ProxyCat** was born! This tool aims to transform short-term IPs (la
 
 [ProxyCat Operation Manual](../main/ProxyCat-Manual/Operation%20Manual.md)
 
+## Updating Code (Important for Docker Users)
+
+When deploying with Docker, the `config/` directory and `docker-compose.yml` contain your personal settings.
+
+Before running `git pull`, back them up. After pulling, restore them to avoid being overwritten:
+
+```bash
+# 1. Backup
+rm -rf backup.bak && mkdir backup.bak
+cp -r config docker-compose.yml backup.bak/
+
+# 2. Pull latest code
+git pull
+
+# 3. Restore your config
+cp -r backup.bak/config ./
+cp backup.bak/docker-compose.yml ./
+```
+
+After restoring, rebuild and restart:
+
+```bash
+docker-compose down
+docker-compose up -d --build
+```
+
 ## Error Troubleshooting
 
 [ProxyCat Investigation Manual](../main/ProxyCat-Manual/Investigation%20Manual.md)

--- a/README.md
+++ b/README.md
@@ -51,9 +51,23 @@
 
 ## 更新代码（Docker 用户必看）
 
-使用 Docker 部署时，`config/` 目录和 `docker-compose.yml` 是你的个人配置。
+使用 Docker 部署时，`config/` 是你的个人配置（已通过 volume 挂载）。
 
-更新代码前请先备份，`git pull` 后再恢复，避免被覆盖：
+### 推荐：本地改动放进 override（不会被 git pull 覆盖）
+
+仓库里的 `docker-compose.yml` 只作基础模板。**请勿直接改它**，把端口、额外挂载、镜像名等本地定制写到：
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+# 编辑 docker-compose.override.yml
+```
+
+Compose 会自动合并 `docker-compose.yml` + `docker-compose.override.yml`。  
+`docker-compose.override.yml` 已加入 `.gitignore`，`git pull` **不会覆盖**你的本地改动。
+
+### 仍在改 docker-compose.yml 时的备份流程
+
+若你以前直接改过 `docker-compose.yml`，更新前请先备份再恢复：
 
 ```bash
 # 1. 备份
@@ -63,9 +77,12 @@ cp -r config docker-compose.yml backup.bak/
 # 2. 拉取最新代码
 git pull
 
-# 3. 恢复配置
+# 3. 恢复配置（建议迁移到 override）
 cp -r backup.bak/config ./
-cp backup.bak/docker-compose.yml ./
+# 推荐：把个人改动迁到 override，而不是覆盖回 docker-compose.yml
+cp backup.bak/docker-compose.yml docker-compose.override.yml
+# 或继续覆盖：
+# cp backup.bak/docker-compose.yml ./
 ```
 
 恢复后重新构建运行：

--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@
 
 [ProxyCat操作手册](../main/ProxyCat-Manual/Operation%20Manual.md)
 
+## 更新代码（Docker 用户必看）
+
+使用 Docker 部署时，`config/` 目录和 `docker-compose.yml` 是你的个人配置。
+
+更新代码前请先备份，`git pull` 后再恢复，避免被覆盖：
+
+```bash
+# 1. 备份
+rm -rf backup.bak && mkdir backup.bak
+cp -r config docker-compose.yml backup.bak/
+
+# 2. 拉取最新代码
+git pull
+
+# 3. 恢复配置
+cp -r backup.bak/config ./
+cp backup.bak/docker-compose.yml ./
+```
+
+恢复后重新构建运行：
+```bash
+docker-compose down
+docker-compose up -d --build
+```
+
 ## 报错排查
 
 [ProxyCat排查手册](../main/ProxyCat-Manual/Investigation%20Manual.md)

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from functools import wraps
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ProxyCat import run_server
-from modules.modules import load_config, check_proxies, check_proxy, check_proxy_detailed, get_message, load_ip_list, normalize_proxy_address, validate_proxy_format
+from modules.modules import load_config, check_proxies, check_proxy, check_proxy_detailed, get_message, load_ip_list, normalize_proxy_address, validate_proxy_format, normalized_check_timeout_ms
 from modules.proxyserver import AsyncProxyServer
 import asyncio
 import threading
@@ -30,6 +30,31 @@ server = AsyncProxyServer(config)
 
 def get_config_path(filename):
     return os.path.join('config', filename)
+
+
+def parse_config_bool(value, field_name):
+    if isinstance(value, bool):
+        return value
+    if str(value).lower() in ('true', 'false'):
+        return str(value).lower() == 'true'
+    raise ValueError(f'{field_name} must be true or false')
+
+
+def validate_health_check_config(new_config):
+    """Validate health-check values before writing config.ini."""
+    if 'proxy_check_timeout_ms' in new_config:
+        value = int(new_config['proxy_check_timeout_ms'])
+        if not 200 <= value <= 60000:
+            raise ValueError('proxy_check_timeout_ms must be between 200 and 60000')
+        new_config['proxy_check_timeout_ms'] = value
+    if 'auto_check_interval_minutes' in new_config:
+        value = int(new_config['auto_check_interval_minutes'])
+        if not 1 <= value <= 10080:
+            raise ValueError('auto_check_interval_minutes must be between 1 and 10080')
+        new_config['auto_check_interval_minutes'] = value
+    for field in ('auto_check_enabled', 'auto_disable_failed_proxies'):
+        if field in new_config:
+            new_config[field] = parse_config_bool(new_config[field], field)
 
 log_file = 'logs/proxycat.log'
 os.makedirs('logs', exist_ok=True)
@@ -138,17 +163,24 @@ def get_status():
         'auth_required': server.auth_required,
         'display_level': int(server_config.get('display_level', '1')),
         'service_status': 'running' if server.running else 'stopped',
+        'auto_check': server.auto_check_status() if hasattr(server, 'auto_check_status') else {},
         'config': server_config
     })
 
 @app.route('/api/config', methods=['POST'])
+@require_token
 def save_config():
     try:
-        new_config = request.get_json()
+        new_config = request.get_json() or {}
+        validate_health_check_config(new_config)
         current_config = load_config('config/config.ini')
-        port_changed = str(new_config.get('port', '')) != str(current_config.get('port', ''))
-        mode_changed = new_config.get('mode', '') != current_config.get('mode', '')
-        use_getip_changed = (new_config.get('use_getip', 'False').lower() == 'true') != (current_config.get('use_getip', 'False').lower() == 'true')
+        port_changed = 'port' in new_config and str(new_config['port']) != str(current_config.get('port', ''))
+        mode_changed = 'mode' in new_config and new_config['mode'] != current_config.get('mode', '')
+        use_getip_changed = (
+            'use_getip' in new_config
+            and (str(new_config['use_getip']).lower() == 'true')
+            != (current_config.get('use_getip', 'False').lower() == 'true')
+        )
         
         config_parser = ConfigParser()
         config_parser.read('config/config.ini', encoding='utf-8')
@@ -170,8 +202,8 @@ def save_config():
         
         server.config = load_config('config/config.ini')
         server._init_config_values(server.config)
-        
-        
+        server.refresh_auto_check_task()
+
         if mode_changed or use_getip_changed:
             server._handle_mode_change()
             
@@ -194,6 +226,7 @@ def save_config():
         })
 
 @app.route('/api/proxies', methods=['GET', 'POST'])
+@require_token
 def handle_proxies():
     if request.method == 'POST':
         try:
@@ -249,7 +282,26 @@ def handle_proxies():
         except Exception:
             return jsonify({'proxies': []})
 
+@app.route('/api/disable_proxies', methods=['POST'])
+@require_token
+def disable_proxies_api():
+    """Persistently disable failed proxy entries when the policy is enabled."""
+    try:
+        if not getattr(server, 'auto_disable_failed_proxies', False):
+            return jsonify({
+                'status': 'error',
+                'message': 'automatic proxy disabling is disabled'
+            }), 409
+        data = request.get_json(silent=True) or {}
+        proxies = data.get('proxies') or []
+        disabled = server.disable_proxy_addresses(proxies)
+        return jsonify({'status': 'success', 'disabled': disabled})
+    except Exception as e:
+        logging.exception('disable_proxies api failed')
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
 @app.route('/api/check_proxy', methods=['POST'])
+@require_token
 def check_single_proxy_api():
     """检测单个代理连通性，供前端逐条测试使用。"""
     try:
@@ -265,12 +317,16 @@ def check_single_proxy_api():
                 'message': get_message('proxy_check_failed', server.language, 'empty proxy')
             }), 400
 
-        detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force))
+        timeout_ms = getattr(server, 'proxy_check_timeout_ms', 2000)
+        detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force, timeout_ms=timeout_ms))
         return jsonify({
             'status': 'success',
             'proxy': proxy,
             'valid': bool(detail.get('valid')),
             'error': detail.get('error'),
+            'timed_out': bool(detail.get('timed_out')),
+            'error_code': detail.get('error_code'),
+            'timeout_ms': detail.get('timeout_ms', timeout_ms),
             'elapsed_ms': detail.get('elapsed_ms', 0),
             'test_url': test_url,
             'cached': bool(detail.get('cached')),
@@ -285,6 +341,7 @@ def check_single_proxy_api():
         })
 
 @app.route('/api/check_proxies', methods=['GET', 'POST'])
+@require_token
 def check_proxies_api():
     try:
         if request.method == 'POST':
@@ -299,16 +356,19 @@ def check_proxies_api():
             proxies = list(server.proxies or [])
             force = True
 
+        timeout_ms = getattr(server, 'proxy_check_timeout_ms', 2000)
         results = []
         valid_proxies = []
         for proxy in proxies:
             proxy = (proxy or '').strip()
             if not proxy or proxy.startswith('#'):
                 continue
-            detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force))
+            detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force, timeout_ms=timeout_ms))
             item = {
                 'proxy': proxy,
                 'valid': bool(detail.get('valid')),
+                'timed_out': bool(detail.get('timed_out')),
+                'error_code': detail.get('error_code'),
                 'error': detail.get('error'),
                 'elapsed_ms': detail.get('elapsed_ms', 0),
             }

--- a/app.py
+++ b/app.py
@@ -12,7 +12,22 @@ from functools import wraps
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ProxyCat import run_server
-from modules.modules import load_config, check_proxies, check_proxy, check_proxy_detailed, get_message, load_ip_list, normalize_proxy_address, validate_proxy_format, normalized_check_timeout_ms
+from modules.modules import (
+    load_config,
+    check_proxies,
+    check_proxy,
+    check_proxy_detailed,
+    get_message,
+    load_ip_list,
+    normalize_proxy_address,
+    validate_proxy_format,
+    normalized_check_timeout_ms,
+    record_ui_check_result,
+    get_ui_check_results,
+    append_ui_check_log,
+    clear_ui_check_logs,
+    get_ui_check_state,
+)
 from modules.proxyserver import AsyncProxyServer
 import asyncio
 import threading
@@ -257,6 +272,7 @@ def handle_proxies():
                 'status': 'success',
                 'message': get_message('proxy_save_success', server.language),
                 'proxies': proxies,
+                'check_results': get_ui_check_results(),
             })
         except Exception as e:
             return jsonify({
@@ -278,9 +294,12 @@ def handle_proxies():
                 body = line[1:].lstrip() if disabled else line
                 norm = normalize_proxy_address(body) or body
                 normalized_list.append(('#' + norm) if disabled else norm)
-            return jsonify({'proxies': normalized_list})
+            return jsonify({
+                'proxies': normalized_list,
+                'check_results': get_ui_check_results(),
+            })
         except Exception:
-            return jsonify({'proxies': []})
+            return jsonify({'proxies': [], 'check_results': {}})
 
 @app.route('/api/disable_proxies', methods=['POST'])
 @require_token
@@ -319,6 +338,7 @@ def check_single_proxy_api():
 
         timeout_ms = getattr(server, 'proxy_check_timeout_ms', 2000)
         detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force, timeout_ms=timeout_ms))
+        record_ui_check_result(proxy, detail, source='manual')
         return jsonify({
             'status': 'success',
             'proxy': proxy,
@@ -364,6 +384,7 @@ def check_proxies_api():
             if not proxy or proxy.startswith('#'):
                 continue
             detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force, timeout_ms=timeout_ms))
+            record_ui_check_result(proxy, detail, source='manual')
             item = {
                 'proxy': proxy,
                 'valid': bool(detail.get('valid')),
@@ -391,6 +412,41 @@ def check_proxies_api():
             'status': 'error',
             'message': get_message('proxy_check_failed', server.language, str(e))
         })
+
+
+@app.route('/api/proxy_check_state', methods=['GET'])
+@require_token
+def proxy_check_state_api():
+    """多浏览器同步：返回最近检测结果与增量检测日志。"""
+    try:
+        since_log_id = request.args.get('since_log_id', 0)
+        state = get_ui_check_state(since_log_id)
+        return jsonify({'status': 'success', **state})
+    except Exception as e:
+        logging.exception('proxy_check_state api failed')
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+@app.route('/api/proxy_check_logs', methods=['POST', 'DELETE'])
+@require_token
+def proxy_check_logs_api():
+    """写入或清空共享检测日志。"""
+    try:
+        if request.method == 'DELETE':
+            clear_id = clear_ui_check_logs()
+            return jsonify({'status': 'success', 'log_clear_id': clear_id})
+
+        data = request.get_json(silent=True) or {}
+        message = data.get('message') or request.args.get('message') or ''
+        level = data.get('level') or request.args.get('level') or 'info'
+        entry = append_ui_check_log(message, level=level, source='client')
+        if not entry:
+            return jsonify({'status': 'error', 'message': 'empty log message'}), 400
+        return jsonify({'status': 'success', **entry})
+    except Exception as e:
+        logging.exception('proxy_check_logs api failed')
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
 
 @app.route('/api/ip_lists', methods=['GET', 'POST'])
 def handle_ip_lists():

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from functools import wraps
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ProxyCat import run_server
-from modules.modules import load_config, check_proxies, get_message, load_ip_list
+from modules.modules import load_config, check_proxies, check_proxy, check_proxy_detailed, get_message, load_ip_list, normalize_proxy_address, validate_proxy_format
 from modules.proxyserver import AsyncProxyServer
 import asyncio
 import threading
@@ -197,7 +197,22 @@ def save_config():
 def handle_proxies():
     if request.method == 'POST':
         try:
-            proxies = request.json.get('proxies', [])
+            raw_proxies = request.json.get('proxies', [])
+            proxies = []
+            for line in raw_proxies:
+                line = (line or '').strip()
+                if not line:
+                    continue
+                # 保留禁用标记，但对内容做协议别名规范化
+                disabled = line.startswith('#')
+                body = line[1:].lstrip() if disabled else line
+                normalized = normalize_proxy_address(body)
+                if not normalized or not validate_proxy_format(normalized):
+                    # 无效行跳过，避免写坏配置
+                    logging.warning(f'skip invalid proxy on save: {line}')
+                    continue
+                proxies.append(('#' + normalized) if disabled else normalized)
+
             proxy_file = get_config_path(os.path.basename(server.proxy_file))
             with open(proxy_file, 'w', encoding='utf-8') as f:
                 f.write('\n'.join(proxies))
@@ -207,7 +222,8 @@ def handle_proxies():
                 server.current_proxy = next(server.proxy_cycle)
             return jsonify({
                 'status': 'success',
-                'message': get_message('proxy_save_success', server.language)
+                'message': get_message('proxy_save_success', server.language),
+                'proxies': proxies,
             })
         except Exception as e:
             return jsonify({
@@ -219,23 +235,98 @@ def handle_proxies():
             proxy_file = get_config_path(os.path.basename(server.proxy_file))
             with open(proxy_file, 'r', encoding='utf-8') as f:
                 proxies = f.read().splitlines()
-            return jsonify({'proxies': proxies})
+            # 读出时也做一次展示向规范化（禁用行保留 #）
+            normalized_list = []
+            for line in proxies:
+                line = (line or '').strip()
+                if not line:
+                    continue
+                disabled = line.startswith('#')
+                body = line[1:].lstrip() if disabled else line
+                norm = normalize_proxy_address(body) or body
+                normalized_list.append(('#' + norm) if disabled else norm)
+            return jsonify({'proxies': normalized_list})
         except Exception:
             return jsonify({'proxies': []})
 
-@app.route('/api/check_proxies')
+@app.route('/api/check_proxy', methods=['POST'])
+def check_single_proxy_api():
+    """检测单个代理连通性，供前端逐条测试使用。"""
+    try:
+        data = request.get_json(silent=True) or {}
+        proxy = (data.get('proxy') or request.args.get('proxy') or '').strip()
+        test_url = (data.get('test_url') or request.args.get('test_url') or 'https://www.baidu.com').strip()
+        force = bool(data.get('force', True))
+
+        if not proxy:
+            return jsonify({
+                'status': 'error',
+                'valid': False,
+                'message': get_message('proxy_check_failed', server.language, 'empty proxy')
+            }), 400
+
+        detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force))
+        return jsonify({
+            'status': 'success',
+            'proxy': proxy,
+            'valid': bool(detail.get('valid')),
+            'error': detail.get('error'),
+            'elapsed_ms': detail.get('elapsed_ms', 0),
+            'test_url': test_url,
+            'cached': bool(detail.get('cached')),
+        })
+    except Exception as e:
+        logging.exception('check_proxy api failed')
+        return jsonify({
+            'status': 'error',
+            'valid': False,
+            'error': str(e),
+            'message': get_message('proxy_check_failed', server.language, str(e))
+        })
+
+@app.route('/api/check_proxies', methods=['GET', 'POST'])
 def check_proxies_api():
     try:
-        test_url = request.args.get('test_url', 'https://www.baidu.com')
-        valid_proxies = asyncio.run(check_proxies(server.proxies, test_url))
+        if request.method == 'POST':
+            data = request.get_json(silent=True) or {}
+            test_url = (data.get('test_url') or 'https://www.baidu.com').strip()
+            proxies = data.get('proxies')
+            if proxies is None:
+                proxies = list(server.proxies or [])
+            force = bool(data.get('force', True))
+        else:
+            test_url = request.args.get('test_url', 'https://www.baidu.com')
+            proxies = list(server.proxies or [])
+            force = True
+
+        results = []
+        valid_proxies = []
+        for proxy in proxies:
+            proxy = (proxy or '').strip()
+            if not proxy or proxy.startswith('#'):
+                continue
+            detail = asyncio.run(check_proxy_detailed(proxy, test_url, force=force))
+            item = {
+                'proxy': proxy,
+                'valid': bool(detail.get('valid')),
+                'error': detail.get('error'),
+                'elapsed_ms': detail.get('elapsed_ms', 0),
+            }
+            results.append(item)
+            if item['valid']:
+                valid_proxies.append(proxy)
+
         total_valid = len(valid_proxies)
         return jsonify({
             'status': 'success',
             'valid_proxies': valid_proxies,
+            'results': results,
             'total': total_valid,
+            'checked': len(results),
             'message': get_message('proxy_check_result', server.language, total_valid)
         })
     except Exception as e:
+        logging.exception('check_proxies api failed')
         return jsonify({
             'status': 'error',
             'message': get_message('proxy_check_failed', server.language, str(e))

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,25 @@
+# 复制为 docker-compose.override.yml 后按需修改。
+# Docker Compose 会自动与 docker-compose.yml 合并；此文件已被 .gitignore，不会被 git pull 覆盖。
+#
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#
+version: '3'
+services:
+  proxycat:
+    # 示例：改本地端口映射
+    # ports:
+    #   - "18080:1080"
+    #   - "15000:5000"
+
+    # 示例：额外挂载日志目录
+    # volumes:
+    #   - ./config:/app/config
+    #   - ./logs:/app/logs
+
+    # 示例：使用已构建镜像而不是每次 build
+    # image: proxycat:local
+    # build: null
+
+    # 示例：环境变量
+    # environment:
+    #   - TZ=Asia/Shanghai

--- a/modules/modules.py
+++ b/modules/modules.py
@@ -515,124 +515,298 @@ def load_ip_list(file_path):
 _proxy_check_cache = {}
 _proxy_check_ttl = 10
 
+# 常见代理协议别名 → 内部标准协议
+PROXY_SCHEME_ALIASES = {
+    'socks5h': 'socks5',  # curl: DNS 也走代理
+    'socks5a': 'socks5',
+    'socks': 'socks5',
+    'socks4a': 'socks5',  # 引擎仅实现 socks5，降级归并避免直接拒收
+    'socks4': 'socks5',
+    'http': 'http',
+    'https': 'https',
+    'socks5': 'socks5',
+}
+
+def normalize_proxy_address(proxy):
+    """规范化代理地址：去空白、补协议、别名归并（socks5h→socks5 等）。"""
+    if proxy is None:
+        return ''
+    s = str(proxy).strip()
+    if not s:
+        return ''
+    # 禁用项以 # 开头时，规范化时先去掉再由调用方决定是否加回
+    disabled = False
+    if s.startswith('#'):
+        disabled = True
+        s = re.sub(r'^#+\s*', '', s).strip()
+        if not s:
+            return ''
+
+    if '://' not in s:
+        s = 'http://' + s
+
+    scheme, rest = s.split('://', 1)
+    scheme = scheme.strip().lower()
+    scheme = PROXY_SCHEME_ALIASES.get(scheme, scheme)
+    rest = rest.strip()
+    normalized = f'{scheme}://{rest}'
+    return f'#{normalized}' if disabled else normalized
+
 def parse_proxy(proxy):
     try:
-        protocol = proxy.split('://')[0]
-        remaining = proxy.split('://')[1]
-        
+        proxy = normalize_proxy_address(proxy)
+        if proxy.startswith('#'):
+            proxy = proxy[1:]
+        if '://' not in proxy:
+            return None, None, None, None
+
+        protocol, remaining = proxy.split('://', 1)
+        protocol = PROXY_SCHEME_ALIASES.get(protocol.lower(), protocol.lower())
+
         if '@' in remaining:
-            auth, address = remaining.split('@')
-            host, port = address.split(':')
-            return protocol, auth, host, int(port)
+            # 只按最后一个 @ 分割，兼容密码中含 : 的情况
+            auth, address = remaining.rsplit('@', 1)
         else:
-            host, port = remaining.split(':')
-            return protocol, None, host, int(port)
+            auth, address = None, remaining
+
+        # host:port —— 从右侧拆端口，兼容将来可能的异常主机写法
+        host, port_s = address.rsplit(':', 1)
+        host = host.strip()
+        # 去掉 IPv6 中括号（若有）
+        if host.startswith('[') and host.endswith(']'):
+            host = host[1:-1]
+        port = int(port_s)
+        if not host or not (0 < port < 65536):
+            return None, None, None, None
+        return protocol, auth, host, port
     except Exception:
         return None, None, None, None
+
+def validate_proxy_format(proxy):
+    """格式是否可被引擎接受（会先做别名规范化）。"""
+    protocol, auth, host, port = parse_proxy(proxy)
+    if protocol not in ('http', 'https', 'socks5'):
+        return False
+    if not host or port is None:
+        return False
+    return 0 < int(port) < 65536
+
+def _proxy_url_from_parts(protocol, auth, host, port):
+    protocol = PROXY_SCHEME_ALIASES.get((protocol or '').lower(), (protocol or '').lower())
+    if auth:
+        return f'{protocol}://{auth}@{host}:{port}'
+    return f'{protocol}://{host}:{port}'
+
+def _httpx_proxy_kwargs(proxy_url):
+    """兼容 httpx 0.27(proxies=) 与 0.28+(proxy=)。"""
+    try:
+        ver = tuple(int(x) for x in httpx.__version__.split('.')[:2])
+    except Exception:
+        ver = (0, 28)
+    if ver >= (0, 28):
+        return {'proxy': proxy_url}
+    return {'proxies': {'http://': proxy_url, 'https://': proxy_url, 'all://': proxy_url}}
 
 async def check_http_proxy(proxy, test_url=None):
     if test_url is None:
         test_url = 'https://www.baidu.com'
     protocol, auth, host, port = parse_proxy(proxy)
-    proxies = {}
-    if auth:
-        proxies['http://'] = f'{protocol}://{auth}@{host}:{port}'
-        proxies['https://'] = f'{protocol}://{auth}@{host}:{port}'
-    else:
-        proxies['http://'] = f'{protocol}://{host}:{port}'
-        proxies['https://'] = f'{protocol}://{host}:{port}'
-        
-    try:
-        async with httpx.AsyncClient(proxies=proxies, timeout=10, verify=False) as client:
-            try:
-                response = await client.get(test_url)
+    if not all([protocol, host, port]):
+        raise ValueError(f'invalid proxy format: {proxy}')
+
+    proxy_url = _proxy_url_from_parts(protocol, auth, host, port)
+    client_kwargs = {
+        'timeout': 10.0,
+        'verify': False,
+        'follow_redirects': True,
+    }
+    client_kwargs.update(_httpx_proxy_kwargs(proxy_url))
+
+    async with httpx.AsyncClient(**client_kwargs) as client:
+        try:
+            response = await client.get(test_url)
+            if response.status_code == 200:
+                return True
+            # 非 200 也尝试 http 回落
+            if test_url.startswith('https://'):
+                http_url = 'http://' + test_url[8:]
+                response = await client.get(http_url)
                 return response.status_code == 200
-            except:
-                if test_url.startswith('https://'):
+            raise RuntimeError(f'HTTP {response.status_code} from {test_url}')
+        except Exception as first_err:
+            if test_url.startswith('https://'):
+                try:
                     http_url = 'http://' + test_url[8:]
                     response = await client.get(http_url)
-                    return response.status_code == 200
-                return False
-    except:
-        return False
+                    if response.status_code == 200:
+                        return True
+                    raise RuntimeError(f'HTTP {response.status_code} from {http_url}') from first_err
+                except Exception:
+                    raise first_err
+            raise
 
 async def check_socks_proxy(proxy, test_url=None):
     if test_url is None:
         test_url = 'https://www.baidu.com'
     protocol, auth, host, port = parse_proxy(proxy)
     if not all([host, port]):
-        return False
-        
+        raise ValueError(f'invalid socks proxy format: {proxy}')
+
+    # 优先用 httpx 走 socks（若已安装 socks 扩展），失败再回落手工握手
+    proxy_url = _proxy_url_from_parts(protocol or 'socks5', auth, host, port)
     try:
-        reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=5)
-        
+        client_kwargs = {
+            'timeout': 10.0,
+            'verify': False,
+            'follow_redirects': True,
+        }
+        client_kwargs.update(_httpx_proxy_kwargs(proxy_url))
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            response = await client.get(test_url)
+            if response.status_code == 200:
+                return True
+            if test_url.startswith('https://'):
+                http_url = 'http://' + test_url[8:]
+                response = await client.get(http_url)
+                if response.status_code == 200:
+                    return True
+            raise RuntimeError(f'HTTP {response.status_code} via socks proxy')
+    except ImportError:
+        pass
+    except Exception:
+        # 回落到原始 SOCKS5 握手探测
+        pass
+
+    reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=5)
+
+    try:
         if auth:
             writer.write(b'\x05\x02\x00\x02')
         else:
             writer.write(b'\x05\x01\x00')
-            
+
         await writer.drain()
-        
+
         auth_method = await asyncio.wait_for(reader.readexactly(2), timeout=5)
         if auth_method[0] != 0x05:
-            return False
-            
+            raise RuntimeError('invalid SOCKS5 version in response')
+
         if auth_method[1] == 0x02 and auth:
             username, password = auth.split(':')
             auth_packet = bytes([0x01, len(username)]) + username.encode() + bytes([len(password)]) + password.encode()
             writer.write(auth_packet)
             await writer.drain()
-            
+
             auth_response = await asyncio.wait_for(reader.readexactly(2), timeout=5)
             if auth_response[1] != 0x00:
-                return False
-        
+                raise RuntimeError('SOCKS5 authentication failed')
+        elif auth_method[1] == 0xFF:
+            raise RuntimeError('SOCKS5 no acceptable auth method')
+
         from urllib.parse import urlparse
         domain = urlparse(test_url).netloc if '://' in test_url else test_url
-        domain = domain.encode()
-        
+        domain = domain.split(':')[0].encode()
+
         writer.write(b'\x05\x01\x00\x03' + bytes([len(domain)]) + domain + b'\x00\x50')
         await writer.drain()
-        
-        response = await asyncio.wait_for(reader.readexactly(10), timeout=5)
-        writer.close()
-        try:
-            await writer.wait_closed()
-        except:
-            pass
-        
-        return response[1] == 0x00
-        
-    except Exception:
-        return False
 
-async def check_proxy(proxy, test_url=None):
+        response = await asyncio.wait_for(reader.readexactly(10), timeout=5)
+        if response[1] != 0x00:
+            raise RuntimeError(f'SOCKS5 connect failed, code={response[1]}')
+        return True
+    finally:
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+async def check_proxy(proxy, test_url=None, force=False):
+    result = await check_proxy_detailed(proxy, test_url=test_url, force=force)
+    return bool(result.get('valid'))
+
+async def check_proxy_detailed(proxy, test_url=None, force=False):
+    """返回 {valid, error, elapsed_ms, proxy, test_url}，供 API/UI 展示真实原因。"""
     current_time = time.time()
+    test_url = test_url or 'https://www.baidu.com'
+    original_proxy = proxy
+    proxy = normalize_proxy_address(proxy)
+    if proxy.startswith('#'):
+        proxy = proxy[1:]
     cache_key = f"{proxy}:{test_url}"
-    
-    if cache_key in _proxy_check_cache:
-        cache_time, is_valid = _proxy_check_cache[cache_key]
+    started = time.time()
+
+    if not force and cache_key in _proxy_check_cache:
+        cache_time, cached = _proxy_check_cache[cache_key]
         if current_time - cache_time < _proxy_check_ttl:
-            return is_valid
-            
-    proxy_type = proxy.split('://')[0]
+            if isinstance(cached, dict):
+                return {
+                    'valid': bool(cached.get('valid')),
+                    'error': cached.get('error'),
+                    'elapsed_ms': cached.get('elapsed_ms', 0),
+                    'proxy': proxy,
+                    'input_proxy': original_proxy,
+                    'test_url': test_url,
+                    'cached': True,
+                }
+            return {
+                'valid': bool(cached),
+                'error': None if cached else 'cached failure',
+                'elapsed_ms': 0,
+                'proxy': proxy,
+                'input_proxy': original_proxy,
+                'test_url': test_url,
+                'cached': True,
+            }
+
+    proxy_type = proxy.split('://')[0].lower() if '://' in (proxy or '') else ''
+    proxy_type = PROXY_SCHEME_ALIASES.get(proxy_type, proxy_type)
     check_funcs = {
         'http': check_http_proxy,
         'https': check_http_proxy,
-        'socks5': check_socks_proxy
+        'socks5': check_socks_proxy,
     }
-    
+
     if proxy_type not in check_funcs:
-        return False
-    
+        result = {
+            'valid': False,
+            'error': f'unsupported scheme: {proxy_type or "(none)"}',
+            'elapsed_ms': int((time.time() - started) * 1000),
+            'proxy': proxy,
+            'input_proxy': original_proxy,
+            'test_url': test_url,
+            'cached': False,
+        }
+        _proxy_check_cache[cache_key] = (time.time(), result)
+        return result
+
     try:
-        test_url = test_url or 'https://www.baidu.com'
         is_valid = await check_funcs[proxy_type](proxy, test_url)
-        _proxy_check_cache[cache_key] = (current_time, is_valid)
-        return is_valid
-    except Exception:
-        _proxy_check_cache[cache_key] = (current_time, False)
-        return False
+        result = {
+            'valid': bool(is_valid),
+            'error': None if is_valid else 'probe returned false',
+            'elapsed_ms': int((time.time() - started) * 1000),
+            'proxy': proxy,
+            'input_proxy': original_proxy,
+            'test_url': test_url,
+            'cached': False,
+        }
+        _proxy_check_cache[cache_key] = (time.time(), result)
+        return result
+    except Exception as e:
+        err = f'{type(e).__name__}: {e}'
+        logging.warning(f'proxy check failed: {proxy} -> {err}')
+        result = {
+            'valid': False,
+            'error': err,
+            'elapsed_ms': int((time.time() - started) * 1000),
+            'proxy': proxy,
+            'input_proxy': original_proxy,
+            'test_url': test_url,
+            'cached': False,
+        }
+        _proxy_check_cache[cache_key] = (time.time(), result)
+        return result
 
 async def check_proxies(proxies, test_url=None):
     valid_proxies = []

--- a/modules/modules.py
+++ b/modules/modules.py
@@ -474,6 +474,10 @@ DEFAULT_CONFIG = {
     'use_getip': 'False',
     'proxy_file': 'ip.txt',
     'check_proxies': 'True',
+    'proxy_check_timeout_ms': '2000',
+    'auto_check_enabled': 'false',
+    'auto_check_interval_minutes': '60',
+    'auto_disable_failed_proxies': 'false',
     'whitelist_file': '',
     'blacklist_file': '',
     'ip_auth_priority': 'whitelist',
@@ -514,6 +518,23 @@ def load_ip_list(file_path):
 
 _proxy_check_cache = {}
 _proxy_check_ttl = 10
+
+# 检测超时安全边界
+CHECK_TIMEOUT_MS_MIN = 200
+CHECK_TIMEOUT_MS_MAX = 60000
+CHECK_TIMEOUT_MS_DEFAULT = 2000
+
+def normalized_check_timeout_ms(value):
+    """解析并限幅用户设置的检测超时（毫秒），非法值退回默认值。"""
+    try:
+        ms = int(float(str(value)))
+    except (TypeError, ValueError):
+        return CHECK_TIMEOUT_MS_DEFAULT
+    if ms < CHECK_TIMEOUT_MS_MIN:
+        return CHECK_TIMEOUT_MS_MIN
+    if ms > CHECK_TIMEOUT_MS_MAX:
+        return CHECK_TIMEOUT_MS_MAX
+    return ms
 
 # 常见代理协议别名 → 内部标准协议
 PROXY_SCHEME_ALIASES = {
@@ -607,133 +628,143 @@ def _httpx_proxy_kwargs(proxy_url):
         return {'proxy': proxy_url}
     return {'proxies': {'http://': proxy_url, 'https://': proxy_url, 'all://': proxy_url}}
 
-async def check_http_proxy(proxy, test_url=None):
+async def check_http_proxy(proxy, test_url=None, timeout_ms=None):
     if test_url is None:
         test_url = 'https://www.baidu.com'
+    timeout_ms = normalized_check_timeout_ms(timeout_ms)
+    timeout_sec = timeout_ms / 1000.0
     protocol, auth, host, port = parse_proxy(proxy)
     if not all([protocol, host, port]):
         raise ValueError(f'invalid proxy format: {proxy}')
 
     proxy_url = _proxy_url_from_parts(protocol, auth, host, port)
     client_kwargs = {
-        'timeout': 10.0,
+        'timeout': timeout_sec,
         'verify': False,
         'follow_redirects': True,
     }
     client_kwargs.update(_httpx_proxy_kwargs(proxy_url))
 
-    async with httpx.AsyncClient(**client_kwargs) as client:
-        try:
-            response = await client.get(test_url)
-            if response.status_code == 200:
-                return True
-            # 非 200 也尝试 http 回落
-            if test_url.startswith('https://'):
-                http_url = 'http://' + test_url[8:]
-                response = await client.get(http_url)
-                return response.status_code == 200
-            raise RuntimeError(f'HTTP {response.status_code} from {test_url}')
-        except Exception as first_err:
-            if test_url.startswith('https://'):
-                try:
+    async def _probe():
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            try:
+                response = await client.get(test_url)
+                if response.status_code == 200:
+                    return True
+                if test_url.startswith('https://'):
                     http_url = 'http://' + test_url[8:]
                     response = await client.get(http_url)
                     if response.status_code == 200:
                         return True
-                    raise RuntimeError(f'HTTP {response.status_code} from {http_url}') from first_err
-                except Exception:
-                    raise first_err
-            raise
+                raise RuntimeError(f'HTTP {response.status_code} from {test_url}')
+            except Exception as first_err:
+                if test_url.startswith('https://'):
+                    try:
+                        http_url = 'http://' + test_url[8:]
+                        response = await client.get(http_url)
+                        if response.status_code == 200:
+                            return True
+                        raise RuntimeError(f'HTTP {response.status_code} from {http_url}') from first_err
+                    except Exception:
+                        raise first_err
+                raise
 
-async def check_socks_proxy(proxy, test_url=None):
+    return await asyncio.wait_for(_probe(), timeout=timeout_sec)
+
+async def check_socks_proxy(proxy, test_url=None, timeout_ms=None):
     if test_url is None:
         test_url = 'https://www.baidu.com'
+    timeout_ms = normalized_check_timeout_ms(timeout_ms)
+    timeout_sec = timeout_ms / 1000.0
     protocol, auth, host, port = parse_proxy(proxy)
     if not all([host, port]):
         raise ValueError(f'invalid socks proxy format: {proxy}')
 
-    # 优先用 httpx 走 socks（若已安装 socks 扩展），失败再回落手工握手
-    proxy_url = _proxy_url_from_parts(protocol or 'socks5', auth, host, port)
-    try:
-        client_kwargs = {
-            'timeout': 10.0,
-            'verify': False,
-            'follow_redirects': True,
-        }
-        client_kwargs.update(_httpx_proxy_kwargs(proxy_url))
-        async with httpx.AsyncClient(**client_kwargs) as client:
-            response = await client.get(test_url)
-            if response.status_code == 200:
-                return True
-            if test_url.startswith('https://'):
-                http_url = 'http://' + test_url[8:]
-                response = await client.get(http_url)
+    async def _probe():
+        # 优先用 httpx 走 socks（若已安装 socks 扩展），失败再回落手工握手
+        proxy_url = _proxy_url_from_parts(protocol or 'socks5', auth, host, port)
+        try:
+            client_kwargs = {
+                'timeout': timeout_sec,
+                'verify': False,
+                'follow_redirects': True,
+            }
+            client_kwargs.update(_httpx_proxy_kwargs(proxy_url))
+            async with httpx.AsyncClient(**client_kwargs) as client:
+                response = await client.get(test_url)
                 if response.status_code == 200:
                     return True
-            raise RuntimeError(f'HTTP {response.status_code} via socks proxy')
-    except ImportError:
-        pass
-    except Exception:
-        # 回落到原始 SOCKS5 握手探测
-        pass
-
-    reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=5)
-
-    try:
-        if auth:
-            writer.write(b'\x05\x02\x00\x02')
-        else:
-            writer.write(b'\x05\x01\x00')
-
-        await writer.drain()
-
-        auth_method = await asyncio.wait_for(reader.readexactly(2), timeout=5)
-        if auth_method[0] != 0x05:
-            raise RuntimeError('invalid SOCKS5 version in response')
-
-        if auth_method[1] == 0x02 and auth:
-            username, password = auth.split(':')
-            auth_packet = bytes([0x01, len(username)]) + username.encode() + bytes([len(password)]) + password.encode()
-            writer.write(auth_packet)
-            await writer.drain()
-
-            auth_response = await asyncio.wait_for(reader.readexactly(2), timeout=5)
-            if auth_response[1] != 0x00:
-                raise RuntimeError('SOCKS5 authentication failed')
-        elif auth_method[1] == 0xFF:
-            raise RuntimeError('SOCKS5 no acceptable auth method')
-
-        from urllib.parse import urlparse
-        domain = urlparse(test_url).netloc if '://' in test_url else test_url
-        domain = domain.split(':')[0].encode()
-
-        writer.write(b'\x05\x01\x00\x03' + bytes([len(domain)]) + domain + b'\x00\x50')
-        await writer.drain()
-
-        response = await asyncio.wait_for(reader.readexactly(10), timeout=5)
-        if response[1] != 0x00:
-            raise RuntimeError(f'SOCKS5 connect failed, code={response[1]}')
-        return True
-    finally:
-        try:
-            writer.close()
-            await writer.wait_closed()
+                if test_url.startswith('https://'):
+                    http_url = 'http://' + test_url[8:]
+                    response = await client.get(http_url)
+                    if response.status_code == 200:
+                        return True
+                raise RuntimeError(f'HTTP {response.status_code} via socks proxy')
+        except ImportError:
+            pass
         except Exception:
             pass
 
-async def check_proxy(proxy, test_url=None, force=False):
-    result = await check_proxy_detailed(proxy, test_url=test_url, force=force)
+        # SOCKS5 手工握手
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=timeout_sec,
+        )
+        try:
+            if auth:
+                writer.write(b'\x05\x02\x00\x02')
+            else:
+                writer.write(b'\x05\x01\x00')
+            await writer.drain()
+
+            auth_method = await asyncio.wait_for(reader.readexactly(2), timeout=timeout_sec)
+            if auth_method[0] != 0x05:
+                raise RuntimeError('invalid SOCKS5 version in response')
+
+            if auth_method[1] == 0x02 and auth:
+                username, password = auth.split(':', 1)
+                auth_packet = bytes([0x01, len(username)]) + username.encode() + bytes([len(password)]) + password.encode()
+                writer.write(auth_packet)
+                await writer.drain()
+                auth_response = await asyncio.wait_for(reader.readexactly(2), timeout=timeout_sec)
+                if auth_response[1] != 0x00:
+                    raise RuntimeError('SOCKS5 authentication failed')
+            elif auth_method[1] == 0xFF:
+                raise RuntimeError('SOCKS5 no acceptable auth method')
+
+            from urllib.parse import urlparse
+            domain = urlparse(test_url).netloc if '://' in test_url else test_url
+            domain = domain.split(':')[0].encode()
+
+            writer.write(b'\x05\x01\x00\x03' + bytes([len(domain)]) + domain + b'\x00\x50')
+            await writer.drain()
+            response = await asyncio.wait_for(reader.readexactly(10), timeout=timeout_sec)
+            if response[1] != 0x00:
+                raise RuntimeError(f'SOCKS5 connect failed, code={response[1]}')
+            return True
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    return await asyncio.wait_for(_probe(), timeout=timeout_sec)
+
+async def check_proxy(proxy, test_url=None, force=False, timeout_ms=None):
+    result = await check_proxy_detailed(proxy, test_url=test_url, force=force, timeout_ms=timeout_ms)
     return bool(result.get('valid'))
 
-async def check_proxy_detailed(proxy, test_url=None, force=False):
-    """返回 {valid, error, elapsed_ms, proxy, test_url}，供 API/UI 展示真实原因。"""
+async def check_proxy_detailed(proxy, test_url=None, force=False, timeout_ms=None):
+    """返回 {valid, error, elapsed_ms, timed_out, error_code, proxy, test_url}，供 API/UI 展示真实原因。"""
+    timeout_ms = normalized_check_timeout_ms(timeout_ms)
     current_time = time.time()
     test_url = test_url or 'https://www.baidu.com'
     original_proxy = proxy
     proxy = normalize_proxy_address(proxy)
     if proxy.startswith('#'):
         proxy = proxy[1:]
-    cache_key = f"{proxy}:{test_url}"
+    cache_key = f"{proxy}:{test_url}:{timeout_ms}"
     started = time.time()
 
     if not force and cache_key in _proxy_check_cache:
@@ -743,6 +774,9 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
                 return {
                     'valid': bool(cached.get('valid')),
                     'error': cached.get('error'),
+                    'timed_out': bool(cached.get('timed_out')),
+                    'error_code': cached.get('error_code'),
+                    'timeout_ms': timeout_ms,
                     'elapsed_ms': cached.get('elapsed_ms', 0),
                     'proxy': proxy,
                     'input_proxy': original_proxy,
@@ -752,6 +786,9 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
             return {
                 'valid': bool(cached),
                 'error': None if cached else 'cached failure',
+                'timed_out': False,
+                'error_code': None,
+                'timeout_ms': timeout_ms,
                 'elapsed_ms': 0,
                 'proxy': proxy,
                 'input_proxy': original_proxy,
@@ -771,6 +808,9 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
         result = {
             'valid': False,
             'error': f'unsupported scheme: {proxy_type or "(none)"}',
+            'timed_out': False,
+            'error_code': 'unsupported_scheme',
+            'timeout_ms': timeout_ms,
             'elapsed_ms': int((time.time() - started) * 1000),
             'proxy': proxy,
             'input_proxy': original_proxy,
@@ -781,10 +821,30 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
         return result
 
     try:
-        is_valid = await check_funcs[proxy_type](proxy, test_url)
+        is_valid = await check_funcs[proxy_type](proxy, test_url, timeout_ms=timeout_ms)
         result = {
             'valid': bool(is_valid),
             'error': None if is_valid else 'probe returned false',
+            'timed_out': False,
+            'error_code': None if is_valid else 'probe_failed',
+            'timeout_ms': timeout_ms,
+            'elapsed_ms': int((time.time() - started) * 1000),
+            'proxy': proxy,
+            'input_proxy': original_proxy,
+            'test_url': test_url,
+            'cached': False,
+        }
+        _proxy_check_cache[cache_key] = (time.time(), result)
+        return result
+    except asyncio.TimeoutError:
+        err = f'timeout after {timeout_ms}ms'
+        logging.warning(f'proxy check timeout: {proxy} -> {err}')
+        result = {
+            'valid': False,
+            'error': err,
+            'timed_out': True,
+            'error_code': 'timeout',
+            'timeout_ms': timeout_ms,
             'elapsed_ms': int((time.time() - started) * 1000),
             'proxy': proxy,
             'input_proxy': original_proxy,
@@ -799,6 +859,9 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
         result = {
             'valid': False,
             'error': err,
+            'timed_out': False,
+            'error_code': 'exception',
+            'timeout_ms': timeout_ms,
             'elapsed_ms': int((time.time() - started) * 1000),
             'proxy': proxy,
             'input_proxy': original_proxy,
@@ -808,10 +871,10 @@ async def check_proxy_detailed(proxy, test_url=None, force=False):
         _proxy_check_cache[cache_key] = (time.time(), result)
         return result
 
-async def check_proxies(proxies, test_url=None):
+async def check_proxies(proxies, test_url=None, timeout_ms=None):
     valid_proxies = []
     for proxy in proxies:
-        if await check_proxy(proxy, test_url):
+        if await check_proxy(proxy, test_url, timeout_ms=timeout_ms):
             valid_proxies.append(proxy)
     return valid_proxies
 

--- a/modules/modules.py
+++ b/modules/modules.py
@@ -1,4 +1,5 @@
-import asyncio, logging, random, httpx, re, os, time
+import asyncio, logging, random, httpx, re, os, time, threading
+from collections import deque
 from configparser import ConfigParser
 from packaging import version
 from colorama import Fore, Style
@@ -519,6 +520,14 @@ def load_ip_list(file_path):
 _proxy_check_cache = {}
 _proxy_check_ttl = 10
 
+# Web UI 共享的检测结果 / 日志（多浏览器同步）
+_ui_check_lock = threading.RLock()
+_ui_check_results = {}  # normalized proxy -> last result
+_ui_check_logs = deque(maxlen=500)
+_ui_check_log_id = 0
+_ui_check_log_clear_id = 0
+_ui_check_revision = 0
+
 # 检测超时安全边界
 CHECK_TIMEOUT_MS_MIN = 200
 CHECK_TIMEOUT_MS_MAX = 60000
@@ -535,6 +544,129 @@ def normalized_check_timeout_ms(value):
     if ms > CHECK_TIMEOUT_MS_MAX:
         return CHECK_TIMEOUT_MS_MAX
     return ms
+
+
+def _normalize_ui_check_proxy_key(proxy):
+    """规范化代理地址，用作 UI 检测结果字典键。"""
+    key = normalize_proxy_address(proxy or '')
+    if key.startswith('#'):
+        key = key[1:]
+    return key
+
+
+def record_ui_check_result(proxy, detail, source='api'):
+    """保存最近一次检测结果，供所有 Web 客户端同步延迟/状态。"""
+    global _ui_check_revision
+    key = _normalize_ui_check_proxy_key(proxy)
+    if not key:
+        return None
+
+    if isinstance(detail, dict):
+        valid = bool(detail.get('valid'))
+        elapsed_ms = detail.get('elapsed_ms', 0)
+        error = detail.get('error')
+        error_code = detail.get('error_code')
+        timed_out = bool(detail.get('timed_out'))
+        test_url = detail.get('test_url')
+    else:
+        valid = bool(detail)
+        elapsed_ms = 0
+        error = None if valid else 'probe failed'
+        error_code = None if valid else 'probe_failed'
+        timed_out = False
+        test_url = None
+
+    try:
+        elapsed_ms = int(elapsed_ms or 0)
+    except (TypeError, ValueError):
+        elapsed_ms = 0
+
+    entry = {
+        'proxy': key,
+        'valid': valid,
+        'status': 'ok' if valid else 'fail',
+        'elapsed_ms': elapsed_ms,
+        'error': error,
+        'error_code': error_code,
+        'timed_out': timed_out,
+        'test_url': test_url,
+        'checked_at': time.time(),
+        'source': source or 'api',
+    }
+    with _ui_check_lock:
+        _ui_check_results[key] = entry
+        _ui_check_revision += 1
+        return dict(entry)
+
+
+def get_ui_check_results():
+    with _ui_check_lock:
+        return {k: dict(v) for k, v in _ui_check_results.items()}
+
+
+def append_ui_check_log(message, level='info', source='client'):
+    """追加一条检测日志；返回带 id 的条目，便于多浏览器增量同步。"""
+    global _ui_check_log_id, _ui_check_revision
+    text = str(message or '').strip()
+    if not text:
+        return None
+    level = level if level in ('info', 'ok', 'fail') else 'info'
+    now = time.time()
+    with _ui_check_lock:
+        _ui_check_log_id += 1
+        _ui_check_revision += 1
+        entry = {
+            'id': _ui_check_log_id,
+            'ts': now,
+            'time': time.strftime('%H:%M:%S', time.localtime(now)),
+            'message': text,
+            'level': level,
+            'source': source or 'client',
+        }
+        _ui_check_logs.append(entry)
+        return dict(entry)
+
+
+def get_ui_check_logs(since_id=0):
+    try:
+        since_id = int(since_id or 0)
+    except (TypeError, ValueError):
+        since_id = 0
+    with _ui_check_lock:
+        if since_id <= 0:
+            return [dict(e) for e in _ui_check_logs]
+        return [dict(e) for e in _ui_check_logs if e['id'] > since_id]
+
+
+def clear_ui_check_logs():
+    """清空检测日志（所有浏览器可见）。"""
+    global _ui_check_log_clear_id, _ui_check_revision
+    with _ui_check_lock:
+        _ui_check_logs.clear()
+        _ui_check_log_clear_id += 1
+        _ui_check_revision += 1
+        return _ui_check_log_clear_id
+
+
+def get_ui_check_state(since_log_id=0):
+    """返回检测结果 + 增量日志，供 Web 轮询。"""
+    try:
+        since_log_id = int(since_log_id or 0)
+    except (TypeError, ValueError):
+        since_log_id = 0
+    with _ui_check_lock:
+        if since_log_id <= 0:
+            logs = [dict(e) for e in _ui_check_logs]
+        else:
+            logs = [dict(e) for e in _ui_check_logs if e['id'] > since_log_id]
+        return {
+            'revision': _ui_check_revision,
+            'log_clear_id': _ui_check_log_clear_id,
+            'latest_log_id': _ui_check_log_id,
+            'results': {k: dict(v) for k, v in _ui_check_results.items()},
+            'logs': logs,
+        }
+
 
 # 常见代理协议别名 → 内部标准协议
 PROXY_SCHEME_ALIASES = {

--- a/modules/proxyserver.py
+++ b/modules/proxyserver.py
@@ -8,7 +8,8 @@ from configparser import ConfigParser
 
 def load_proxies(file_path='ip.txt'):
     with open(file_path, 'r') as file:
-        return [line.strip() for line in file if '://' in line]
+        return [line.strip() for line in file
+                if '://' in line and not line.strip().startswith('#')]
 
 def validate_proxy(proxy):
     pattern = re.compile(r'^(?P<scheme>socks5|http|https)://(?:(?P<auth>[^@]+)@)?(?P<host>[^:]+):(?P<port>\d+)$')
@@ -179,7 +180,8 @@ class AsyncProxyServer:
             proxy_file = os.path.join('config', os.path.basename(self.proxy_file))
             if os.path.exists(proxy_file):
                 with open(proxy_file, 'r', encoding='utf-8') as f:
-                    proxies = [line.strip() for line in f if line.strip()]
+                    proxies = [line.strip() for line in f
+                               if line.strip() and not line.strip().startswith('#')]
                 return proxies
             else:
                 logging.error(get_message('proxy_file_not_found', self.language, proxy_file))

--- a/modules/proxyserver.py
+++ b/modules/proxyserver.py
@@ -1,5 +1,5 @@
-import asyncio, httpx, logging, re, socket, struct, time, base64, random, os
-from modules.modules import get_message, load_ip_list, normalize_proxy_address, validate_proxy_format, PROXY_SCHEME_ALIASES
+import asyncio, httpx, logging, re, socket, struct, time, base64, random, os, threading, tempfile
+from modules.modules import get_message, load_ip_list, normalize_proxy_address, validate_proxy_format, PROXY_SCHEME_ALIASES, normalized_check_timeout_ms
 from asyncio import TimeoutError
 from itertools import cycle
 from config import getip
@@ -59,6 +59,18 @@ class AsyncProxyServer:
         self.ip_auth_priority = config.get('ip_auth_priority', 'whitelist')
         
         self.test_url = config.get('test_url', 'https://www.baidu.com')
+        # 健康检测设置
+        self.proxy_check_timeout_ms = normalized_check_timeout_ms(
+            config.get('proxy_check_timeout_ms', '2000')
+        )
+        self.auto_check_enabled = config.get('auto_check_enabled', 'false').lower() == 'true'
+        self.auto_check_interval_minutes = max(
+            1,
+            int(config.get('auto_check_interval_minutes', '60') or '60')
+        )
+        self.auto_disable_failed_proxies = config.get(
+            'auto_disable_failed_proxies', 'false'
+        ).lower() == 'true'
         self.whitelist = load_ip_list(self.whitelist_file)
         self.blacklist = load_ip_list(self.blacklist_file)
         
@@ -73,8 +85,17 @@ class AsyncProxyServer:
         self.proxy_check_ttl = 60
         self.check_cooldown = 10
         self.connected_clients = set()
-        self.last_proxy_failure_time = 0  
-        self.proxy_failure_cooldown = 3  
+        self.last_proxy_failure_time = 0
+        self.proxy_failure_cooldown = 3
+        # 自动健康检测状态仅在实例首次初始化时创建；热更新配置不得重置任务/锁。
+        if not hasattr(self, '_auto_check_lock'):
+            self._auto_check_task = None
+            self._auto_check_lock = asyncio.Lock()
+            self._proxy_file_lock = threading.RLock()
+            self._last_auto_check_at = None
+            self._last_auto_check_summary = None
+            self._auto_check_wakeup = asyncio.Event()
+            self._event_loop = None
 
     def _init_server_state(self):
         self.running = False
@@ -205,6 +226,155 @@ class AsyncProxyServer:
             logging.error(get_message('load_proxy_file_error', self.language, str(e)))
             return []
 
+    def disable_proxy_addresses(self, addresses):
+        """将指定的已启用代理行注释为禁用，保留其它行及已有注释。"""
+        addresses = {
+            normalize_proxy_address(addr).lstrip('#')
+            for addr in addresses
+            if addr
+        }
+        if not addresses:
+            return 0
+
+        with self._proxy_file_lock:
+            if not os.path.exists(self.proxy_file):
+                return 0
+            with open(self.proxy_file, 'r', encoding='utf-8') as f:
+                lines = f.read().splitlines()
+
+            changed = 0
+            updated = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped and not stripped.startswith('#'):
+                    normalized = normalize_proxy_address(stripped)
+                    if normalized in addresses:
+                        updated.append('#' + stripped)
+                        changed += 1
+                        continue
+                updated.append(line)
+
+            if not changed:
+                return 0
+
+            directory = os.path.dirname(os.path.abspath(self.proxy_file))
+            fd, temp_path = tempfile.mkstemp(prefix='.proxycat-', dir=directory, text=True)
+            try:
+                with os.fdopen(fd, 'w', encoding='utf-8', newline='') as f:
+                    f.write('\n'.join(updated) + '\n')
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp_path, self.proxy_file)
+            finally:
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+
+            self.proxies = self._load_file_proxies()
+            self.proxy_cycle = cycle(self.proxies) if self.proxies else None
+            self.current_proxy = next(self.proxy_cycle) if self.proxy_cycle else None
+            logging.warning(f'自动禁用 {changed} 个检测失败代理')
+            return changed
+
+    async def _run_auto_check(self):
+        if self.use_getip or not self.auto_check_enabled:
+            return
+        async with self._auto_check_lock:
+            enabled_proxies = list(self.proxies)
+            if not enabled_proxies:
+                self._last_auto_check_summary = {
+                    'checked': 0, 'valid': 0, 'failed': 0, 'disabled': 0
+                }
+                return
+
+            semaphore = asyncio.Semaphore(5)
+
+            async def probe(proxy):
+                async with semaphore:
+                    from modules.modules import check_proxy_detailed
+                    return proxy, await check_proxy_detailed(
+                        proxy,
+                        test_url=self.test_url,
+                        force=True,
+                        timeout_ms=self.proxy_check_timeout_ms,
+                    )
+
+            results = await asyncio.gather(*(probe(proxy) for proxy in enabled_proxies))
+            failed = [proxy for proxy, result in results if not result.get('valid')]
+            disabled = 0
+            if self.auto_disable_failed_proxies and failed:
+                disabled = self.disable_proxy_addresses(failed)
+
+            self._last_auto_check_at = time.time()
+            self._last_auto_check_summary = {
+                'checked': len(results),
+                'valid': len(results) - len(failed),
+                'failed': len(failed),
+                'disabled': disabled,
+            }
+            logging.info(
+                '自动代理检测完成: 检测 %s，成功 %s，失败 %s，禁用 %s',
+                len(results), len(results) - len(failed), len(failed), disabled
+            )
+
+    async def _auto_check_loop(self):
+        while self.running and self.auto_check_enabled and not self.use_getip:
+            try:
+                self._auto_check_wakeup.clear()
+                await asyncio.wait_for(
+                    self._auto_check_wakeup.wait(),
+                    timeout=self.auto_check_interval_minutes * 60,
+                )
+                continue
+            except asyncio.TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                raise
+
+            if self.running and self.auto_check_enabled and not self.use_getip:
+                try:
+                    await self._run_auto_check()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logging.error(f'自动代理检测出错: {e}')
+
+    async def _configure_auto_check_task(self):
+        old_task = self._auto_check_task
+        if old_task and not old_task.done():
+            old_task.cancel()
+            if old_task is not asyncio.current_task():
+                await asyncio.gather(old_task, return_exceptions=True)
+        self._auto_check_task = None
+
+        if self.running and self.auto_check_enabled and not self.use_getip:
+            task = asyncio.create_task(self._auto_check_loop())
+            self._auto_check_task = task
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+
+    def refresh_auto_check_task(self):
+        """供 Flask 配置写入后安全刷新自动检测任务。"""
+        if not self._event_loop or not self.running:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self._configure_auto_check_task(),
+                self._event_loop,
+            )
+        except RuntimeError:
+            pass
+
+    def auto_check_status(self):
+        return {
+            'enabled': self.auto_check_enabled and not self.use_getip,
+            'interval_minutes': self.auto_check_interval_minutes,
+            'timeout_ms': self.proxy_check_timeout_ms,
+            'auto_disable': self.auto_disable_failed_proxies,
+            'running': bool(self._auto_check_task and not self._auto_check_task.done()),
+            'last_run_at': self._last_auto_check_at,
+            'summary': self._last_auto_check_summary,
+        }
+
     async def start(self):
         if not self.running:
             self.stop_server = False
@@ -234,11 +404,13 @@ class AsyncProxyServer:
                 )
                 
                 self.server_instance = server
+                self._event_loop = asyncio.get_running_loop()
                 logging.info(get_message('server_running', self.language, '0.0.0.0', self.port))
-                
+
                 self.tasks.add(asyncio.create_task(self.cleanup_clients()))
                 self.tasks.add(asyncio.create_task(self._cleanup_pool()))
                 self.tasks.add(asyncio.create_task(self.cleanup_disconnected_ips()))
+                await self._configure_auto_check_task()
                 
                 if hasattr(os, 'sched_setaffinity'):
                     try:

--- a/modules/proxyserver.py
+++ b/modules/proxyserver.py
@@ -300,6 +300,13 @@ class AsyncProxyServer:
 
             results = await asyncio.gather(*(probe(proxy) for proxy in enabled_proxies))
             failed = [proxy for proxy, result in results if not result.get('valid')]
+            try:
+                from modules.modules import record_ui_check_result, append_ui_check_log
+                for proxy, result in results:
+                    record_ui_check_result(proxy, result, source='auto')
+            except Exception as e:
+                logging.debug(f'record auto-check UI results failed: {e}')
+
             disabled = 0
             if self.auto_disable_failed_proxies and failed:
                 disabled = self.disable_proxy_addresses(failed)
@@ -311,10 +318,16 @@ class AsyncProxyServer:
                 'failed': len(failed),
                 'disabled': disabled,
             }
-            logging.info(
-                '自动代理检测完成: 检测 %s，成功 %s，失败 %s，禁用 %s',
-                len(results), len(results) - len(failed), len(failed), disabled
+            summary_msg = (
+                f'自动代理检测完成: 检测 {len(results)}，'
+                f'成功 {len(results) - len(failed)}，失败 {len(failed)}，禁用 {disabled}'
             )
+            logging.info(summary_msg)
+            try:
+                from modules.modules import append_ui_check_log
+                append_ui_check_log(summary_msg, level='info', source='auto')
+            except Exception:
+                pass
 
     async def _auto_check_loop(self):
         while self.running and self.auto_check_enabled and not self.use_getip:

--- a/modules/proxyserver.py
+++ b/modules/proxyserver.py
@@ -275,14 +275,85 @@ class AsyncProxyServer:
             logging.warning(f'自动禁用 {changed} 个检测失败代理')
             return changed
 
+    def load_all_proxies(self):
+        """加载文件中的所有代理（包括已被 # 注释掉的禁用代理）"""
+        try:
+            proxy_file = os.path.join('config', os.path.basename(self.proxy_file))
+            if os.path.exists(proxy_file):
+                with open(proxy_file, 'r', encoding='utf-8') as f:
+                    proxies = []
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        normalized = normalize_proxy_address(line)
+                        if normalized and validate_proxy(normalized):
+                            proxies.append(normalized)
+                    return proxies
+            else:
+                return []
+        except Exception as e:
+            logging.error(f"加载所有代理列表失败: {e}")
+            return []
+
+    def enable_proxy_addresses(self, addresses):
+        """将指定的代理行从禁用状态移除（移除 # 前缀）"""
+        addresses = {
+            normalize_proxy_address(addr).lstrip('#')
+            for addr in addresses
+            if addr
+        }
+        if not addresses:
+            return 0
+
+        with self._proxy_file_lock:
+            if not os.path.exists(self.proxy_file):
+                return 0
+            with open(self.proxy_file, 'r', encoding='utf-8') as f:
+                lines = f.read().splitlines()
+
+            changed = 0
+            updated = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped and stripped.startswith('#'):
+                    normalized = normalize_proxy_address(stripped[1:])
+                    if normalized in addresses:
+                        updated.append(stripped[1:])
+                        changed += 1
+                        continue
+                updated.append(line)
+
+            if not changed:
+                return 0
+
+            directory = os.path.dirname(os.path.abspath(self.proxy_file))
+            fd, temp_path = tempfile.mkstemp(prefix='.proxycat-', dir=directory, text=True)
+            try:
+                with os.fdopen(fd, 'w', encoding='utf-8', newline='') as f:
+                    f.write('\n'.join(updated) + '\n')
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp_path, self.proxy_file)
+            finally:
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+
+            self.proxies = self.load_all_proxies()
+            self.proxy_cycle = cycle(self.proxies) if self.proxies else None
+            if self.proxies:
+                self.current_proxy = next(self.proxy_cycle)
+            logging.info(f'自动重新启用 {changed} 个代理')
+            return changed
+
     async def _run_auto_check(self):
         if self.use_getip or not self.auto_check_enabled:
             return
         async with self._auto_check_lock:
-            enabled_proxies = list(self.proxies)
-            if not enabled_proxies:
+            all_proxies = self.load_all_proxies()
+            if not all_proxies:
                 self._last_auto_check_summary = {
-                    'checked': 0, 'valid': 0, 'failed': 0, 'disabled': 0
+                    'checked': 0, 'valid': 0, 'failed': 0, 'disabled': 0, 're_enabled': 0
                 }
                 return
 
@@ -298,8 +369,8 @@ class AsyncProxyServer:
                         timeout_ms=self.proxy_check_timeout_ms,
                     )
 
-            results = await asyncio.gather(*(probe(proxy) for proxy in enabled_proxies))
-            failed = [proxy for proxy, result in results if not result.get('valid')]
+            results = await asyncio.gather(*(probe(proxy) for proxy in all_proxies))
+
             try:
                 from modules.modules import record_ui_check_result, append_ui_check_log
                 for proxy, result in results:
@@ -307,9 +378,17 @@ class AsyncProxyServer:
             except Exception as e:
                 logging.debug(f'record auto-check UI results failed: {e}')
 
+            failed = [proxy for proxy, result in results if not result.get('valid')]
             disabled = 0
-            if self.auto_disable_failed_proxies and failed:
+            re_enabled = 0
+
+            if failed:
                 disabled = self.disable_proxy_addresses(failed)
+
+            # 重新启用检测成功的代理（即使之前被禁用）
+            valid_proxies = [p for p, result in results if result.get('valid')]
+            if valid_proxies:
+                re_enabled = self.enable_proxy_addresses(valid_proxies)
 
             self._last_auto_check_at = time.time()
             self._last_auto_check_summary = {
@@ -317,10 +396,13 @@ class AsyncProxyServer:
                 'valid': len(results) - len(failed),
                 'failed': len(failed),
                 'disabled': disabled,
+                're_enabled': re_enabled
             }
+
             summary_msg = (
                 f'自动代理检测完成: 检测 {len(results)}，'
-                f'成功 {len(results) - len(failed)}，失败 {len(failed)}，禁用 {disabled}'
+                f'成功 {len(results) - len(failed)}，失败 {len(failed)}，'
+                f'禁用 {disabled}，重新启用 {re_enabled}'
             )
             logging.info(summary_msg)
             try:

--- a/modules/proxyserver.py
+++ b/modules/proxyserver.py
@@ -1,5 +1,5 @@
 import asyncio, httpx, logging, re, socket, struct, time, base64, random, os
-from modules.modules import get_message, load_ip_list
+from modules.modules import get_message, load_ip_list, normalize_proxy_address, validate_proxy_format, PROXY_SCHEME_ALIASES
 from asyncio import TimeoutError
 from itertools import cycle
 from config import getip
@@ -8,17 +8,24 @@ from configparser import ConfigParser
 
 def load_proxies(file_path='ip.txt'):
     with open(file_path, 'r') as file:
-        return [line.strip() for line in file
-                if '://' in line and not line.strip().startswith('#')]
+        result = []
+        for line in file:
+            line = line.strip()
+            if not line or line.startswith('#') or '://' not in line:
+                continue
+            normalized = normalize_proxy_address(line)
+            if normalized and validate_proxy_format(normalized):
+                result.append(normalized)
+        return result
 
 def validate_proxy(proxy):
-    pattern = re.compile(r'^(?P<scheme>socks5|http|https)://(?:(?P<auth>[^@]+)@)?(?P<host>[^:]+):(?P<port>\d+)$')
-    match = pattern.match(proxy)
-    if not match:
+    """兼容 socks5h/socks5a 等别名，规范化后校验。"""
+    if not proxy:
         return False
-    
-    port = int(match.group('port'))
-    return 0 < port < 65536
+    normalized = normalize_proxy_address(proxy)
+    if normalized.startswith('#'):
+        normalized = normalized[1:]
+    return validate_proxy_format(normalized)
 
 class AsyncProxyServer:
     def __init__(self, config):
@@ -180,8 +187,16 @@ class AsyncProxyServer:
             proxy_file = os.path.join('config', os.path.basename(self.proxy_file))
             if os.path.exists(proxy_file):
                 with open(proxy_file, 'r', encoding='utf-8') as f:
-                    proxies = [line.strip() for line in f
-                               if line.strip() and not line.strip().startswith('#')]
+                    proxies = []
+                    for line in f:
+                        line = line.strip()
+                        if not line or line.startswith('#'):
+                            continue
+                        normalized = normalize_proxy_address(line)
+                        if normalized and validate_proxy(normalized):
+                            proxies.append(normalized)
+                        elif line:
+                            logging.warning(f'跳过无效代理行: {line}')
                 return proxies
             else:
                 logging.error(get_message('proxy_file_not_found', self.language, proxy_file))
@@ -451,35 +466,49 @@ class AsyncProxyServer:
         return None, proxy_addr
 
     async def _create_client(self, proxy):
-        proxy_type, proxy_addr = proxy.split('://')
+        proxy = normalize_proxy_address(proxy)
+        if proxy.startswith('#'):
+            proxy = proxy[1:]
+        proxy_type, proxy_addr = proxy.split('://', 1)
+        proxy_type = PROXY_SCHEME_ALIASES.get(proxy_type.lower(), proxy_type.lower())
         proxy_auth = None
-        
+
         if '@' in proxy_addr:
-            auth, proxy_addr = proxy_addr.split('@')
+            auth, proxy_addr = proxy_addr.rsplit('@', 1)
             proxy_auth = auth
-        
+
         if proxy_auth:
             proxy_url = f"{proxy_type}://{proxy_auth}@{proxy_addr}"
         else:
             proxy_url = f"{proxy_type}://{proxy_addr}"
-            
+
         import logging as httpx_logging
         httpx_logging.getLogger("httpx").setLevel(logging.WARNING)
         httpx_logging.getLogger("hpack").setLevel(logging.WARNING)
         httpx_logging.getLogger("h2").setLevel(logging.WARNING)
-            
-        return httpx.AsyncClient(
-            proxies={"all://": proxy_url},
-            limits=httpx.Limits(
+
+        # 兼容 httpx 0.27(proxies=) / 0.28+(proxy=)
+        client_kwargs = {
+            'limits': httpx.Limits(
                 max_keepalive_connections=100,
                 max_connections=1000,
                 keepalive_expiry=30
             ),
-            timeout=30.0,
-            http2=True,
-            verify=False,
-            follow_redirects=True
-        )
+            'timeout': 30.0,
+            'http2': True,
+            'verify': False,
+            'follow_redirects': True,
+        }
+        try:
+            ver = tuple(int(x) for x in httpx.__version__.split('.')[:2])
+        except Exception:
+            ver = (0, 28)
+        if ver >= (0, 28):
+            client_kwargs['proxy'] = proxy_url
+        else:
+            client_kwargs['proxies'] = {"all://": proxy_url}
+
+        return httpx.AsyncClient(**client_kwargs)
 
     async def _cleanup_connections(self):
         current_time = time.time()

--- a/web/static/css/forms.css
+++ b/web/static/css/forms.css
@@ -34,8 +34,16 @@
 @media (prefers-color-scheme: dark) {
     .form-control, .form-select {
         background-color: #2d2d2d;
-        color: #ffffff;
+        color: #f0f0f0;
         border-color: #3d3d3d;
+        caret-color: #4a90e2;
+    }
+
+    /* 暗色模式下占位提示文字保持足够对比度，避免几乎不可见 */
+    .form-control::placeholder,
+    .form-select::placeholder {
+        color: #8a929f;
+        opacity: 1;
     }
 
     .table {

--- a/web/static/css/status-card.css
+++ b/web/static/css/status-card.css
@@ -526,17 +526,19 @@
 
 .proxy-actions {
     display: flex;
-    gap: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
     margin-top: 1rem;
 }
 
 .proxy-actions .btn {
-    padding: 10px 20px;
+    padding: 10px 18px;
     font-size: 0.9rem;
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    min-width: 120px;
+    min-width: 110px;
     justify-content: center;
     border-radius: 8px;
     transition: all 0.3s ease;
@@ -544,6 +546,20 @@
 
 .proxy-actions .btn i {
     font-size: 1rem;
+}
+
+.proxy-actions .btn:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.proxy-check-progress {
+    font-size: 0.88rem;
+    color: var(--text-color);
+    opacity: 0.85;
+    margin-left: 4px;
+    white-space: nowrap;
 }
 
 /* IP名单标签页样式 */
@@ -848,10 +864,12 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    flex-wrap: wrap;
 }
 
 .proxy-count #proxy-total,
-.proxy-count #proxy-enabled-count {
+.proxy-count #proxy-enabled-count,
+.proxy-count #proxy-selected-count {
     font-weight: 700;
     color: #4a90e2;
 }
@@ -860,9 +878,40 @@
     opacity: 0.4;
 }
 
+.proxy-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.proxy-select-all input[type="checkbox"],
+.proxy-select input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    cursor: pointer;
+    accent-color: #4a90e2;
+    flex: 0 0 auto;
+}
+
+.proxy-select {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    flex: 0 0 auto;
+    cursor: pointer;
+}
+
 .proxy-toolbar-actions {
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
 }
 
 .btn-toolbar {
@@ -881,6 +930,17 @@
 .btn-toolbar:hover {
     border-color: #4a90e2;
     color: #4a90e2;
+}
+
+.btn-toolbar-danger {
+    color: #c53030;
+    border-color: rgba(197, 48, 48, 0.28);
+}
+
+.btn-toolbar-danger:hover {
+    border-color: #dc3545;
+    color: #dc3545;
+    background: rgba(220, 53, 69, 0.08);
 }
 
 .proxy-items {
@@ -906,6 +966,10 @@
 
 .proxy-item:hover {
     background: rgba(74, 144, 226, 0.06);
+}
+
+.proxy-item.selected {
+    background: rgba(74, 144, 226, 0.1);
 }
 
 .proxy-item.disabled .proxy-addr,
@@ -1010,6 +1074,54 @@
     color: #dc3545;
 }
 
+.proxy-test {
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #8a93a0;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.proxy-test:hover {
+    background: rgba(74, 144, 226, 0.12);
+    color: #4a90e2;
+}
+
+.proxy-test.is-testing {
+    color: #e6a23c;
+    background: rgba(230, 162, 60, 0.12);
+    cursor: wait;
+}
+
+.proxy-test.is-ok {
+    color: #1f9d55;
+    background: rgba(31, 157, 85, 0.12);
+}
+
+.proxy-test.is-ok:hover {
+    color: #178a48;
+    background: rgba(31, 157, 85, 0.18);
+}
+
+.proxy-test.is-fail {
+    color: #dc3545;
+    background: rgba(220, 53, 69, 0.12);
+}
+
+.proxy-test.is-fail:hover {
+    color: #c82333;
+    background: rgba(220, 53, 69, 0.18);
+}
+
+.proxy-test:disabled {
+    opacity: 0.85;
+    cursor: wait;
+}
+
 .proxy-empty {
     text-align: center;
     padding: 28px 10px;
@@ -1041,6 +1153,76 @@
     white-space: nowrap;
 }
 
+.proxy-check-log-panel {
+    margin-top: 16px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.55);
+    overflow: hidden;
+}
+
+.proxy-check-log-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 12px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.proxy-check-log-header i {
+    margin-right: 6px;
+    color: #4a90e2;
+}
+
+.proxy-check-log {
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 10px 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    color: var(--text-color);
+    background: rgba(0, 0, 0, 0.02);
+}
+
+.proxy-check-log-placeholder {
+    color: #90979f;
+    text-align: center;
+    padding: 18px 8px;
+}
+
+.proxy-check-log-line {
+    display: flex;
+    gap: 10px;
+    padding: 2px 0;
+    word-break: break-all;
+}
+
+.proxy-check-log-time {
+    flex: 0 0 auto;
+    color: #8a93a0;
+}
+
+.proxy-check-log-msg {
+    flex: 1 1 auto;
+}
+
+.proxy-check-log-line.is-ok .proxy-check-log-msg {
+    color: #1f9d55;
+}
+
+.proxy-check-log-line.is-fail .proxy-check-log-msg {
+    color: #dc3545;
+}
+
+.proxy-check-log-line.is-info .proxy-check-log-msg {
+    color: #4a90e2;
+}
+
 /* ===== 暗色模式 ===== */
 @media (prefers-color-scheme: dark) {
     .btn-toolbar {
@@ -1054,6 +1236,18 @@
         color: #7db4ee;
     }
 
+    .btn-toolbar-danger {
+        color: #ff8a95;
+        border-color: rgba(255, 107, 122, 0.35);
+        background: #33373e;
+    }
+
+    .btn-toolbar-danger:hover {
+        border-color: #ff6b7a;
+        color: #ff6b7a;
+        background: rgba(220, 53, 69, 0.18);
+    }
+
     .proxy-items {
         background: rgba(255, 255, 255, 0.03);
         border-color: rgba(255, 255, 255, 0.1);
@@ -1065,6 +1259,10 @@
 
     .proxy-item:hover {
         background: rgba(74, 144, 226, 0.12);
+    }
+
+    .proxy-item.selected {
+        background: rgba(74, 144, 226, 0.18);
     }
 
     .proxy-addr {
@@ -1084,7 +1282,52 @@
         color: #ff6b7a;
     }
 
+    .proxy-test {
+        color: #8a929f;
+    }
+
+    .proxy-test:hover {
+        background: rgba(74, 144, 226, 0.18);
+        color: #7db4ee;
+    }
+
+    .proxy-test.is-testing {
+        color: #f0c36a;
+        background: rgba(230, 162, 60, 0.18);
+    }
+
+    .proxy-test.is-ok {
+        color: #3dd68c;
+        background: rgba(31, 157, 85, 0.18);
+    }
+
+    .proxy-test.is-fail {
+        color: #ff6b7a;
+        background: rgba(220, 53, 69, 0.18);
+    }
+
     .proxy-empty {
         color: #8a929f;
+    }
+
+    .proxy-check-log-panel {
+        background: rgba(255, 255, 255, 0.03);
+        border-color: rgba(255, 255, 255, 0.1);
+    }
+
+    .proxy-check-log-header {
+        border-bottom-color: rgba(255, 255, 255, 0.08);
+    }
+
+    .proxy-check-log {
+        background: rgba(0, 0, 0, 0.25);
+    }
+
+    .proxy-check-log-placeholder {
+        color: #8a929f;
+    }
+
+    .proxy-check-log-time {
+        color: #7d838c;
     }
 } 

--- a/web/static/css/status-card.css
+++ b/web/static/css/status-card.css
@@ -671,16 +671,22 @@
     }
     
     .proxy-list-help {
-        color: #888;
+        color: #9aa3b0;
     }
-    
+
     .proxy-list-section textarea {
-        background: rgba(0, 0, 0, 0.2);
-        color: #e0e0e0;
+        background: #23262b;
+        color: #f0f0f0;
+        caret-color: #4a90e2;
     }
-    
+
+    .proxy-list-section textarea::placeholder {
+        color: #8a929f;
+        opacity: 1;
+    }
+
     .proxy-list-section textarea:focus {
-        background: rgba(0, 0, 0, 0.3);
+        background: #2b2f36;
     }
 }
 
@@ -824,4 +830,261 @@
 .service-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+}
+
+/* ===== 代理管理：启用/禁用列表 ===== */
+.proxy-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.proxy-count {
+    font-size: 0.9rem;
+    color: var(--text-color);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.proxy-count #proxy-total,
+.proxy-count #proxy-enabled-count {
+    font-weight: 700;
+    color: #4a90e2;
+}
+
+.proxy-count-sep {
+    opacity: 0.4;
+}
+
+.proxy-toolbar-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.btn-toolbar {
+    padding: 5px 12px;
+    font-size: 0.82rem;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    background: #fff;
+    color: #4a5568;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    transition: all 0.2s ease;
+}
+
+.btn-toolbar:hover {
+    border-color: #4a90e2;
+    color: #4a90e2;
+}
+
+.proxy-items {
+    max-height: 340px;
+    overflow-y: auto;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.5);
+}
+
+.proxy-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    transition: background 0.2s ease;
+}
+
+.proxy-item:last-child {
+    border-bottom: none;
+}
+
+.proxy-item:hover {
+    background: rgba(74, 144, 226, 0.06);
+}
+
+.proxy-item.disabled .proxy-addr,
+.proxy-item.disabled .proxy-proto {
+    opacity: 0.4;
+    text-decoration: line-through;
+}
+
+/* 开关 */
+.proxy-switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 22px;
+    flex: 0 0 auto;
+    margin: 0;
+}
+
+.proxy-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.proxy-slider {
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+    background: #cbd2d9;
+    border-radius: 22px;
+    transition: background 0.25s ease;
+}
+
+.proxy-slider::before {
+    content: '';
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 3px;
+    top: 3px;
+    background: #fff;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.25s ease;
+}
+
+.proxy-switch input:checked + .proxy-slider {
+    background: #4a90e2;
+}
+
+.proxy-switch input:checked + .proxy-slider::before {
+    transform: translateX(18px);
+}
+
+.proxy-switch input:focus-visible + .proxy-slider {
+    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.25);
+}
+
+/* 协议标签 */
+.proxy-proto {
+    flex: 0 0 auto;
+    min-width: 58px;
+    text-align: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+    padding: 3px 8px;
+    border-radius: 5px;
+    color: #fff;
+    background: #6c757d;
+}
+
+.proxy-proto-http { background: #3fa796; }
+.proxy-proto-https { background: #2f855a; }
+.proxy-proto-socks5 { background: #805ad5; }
+
+.proxy-addr {
+    flex: 1 1 auto;
+    font-family: monospace;
+    font-size: 0.9rem;
+    color: var(--text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.proxy-del {
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #b0b7c0;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.proxy-del:hover {
+    background: rgba(220, 53, 69, 0.12);
+    color: #dc3545;
+}
+
+.proxy-empty {
+    text-align: center;
+    padding: 28px 10px;
+    color: #90979f;
+    font-size: 0.9rem;
+}
+
+.proxy-add {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin-top: 14px;
+}
+
+.proxy-add textarea {
+    flex: 1 1 auto;
+    font-family: monospace;
+    font-size: 0.9rem;
+    resize: vertical;
+}
+
+.proxy-add-btn {
+    flex: 0 0 auto;
+    align-self: stretch;
+    padding: 10px 18px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+/* ===== 暗色模式 ===== */
+@media (prefers-color-scheme: dark) {
+    .btn-toolbar {
+        background: #33373e;
+        border-color: rgba(255, 255, 255, 0.14);
+        color: #cfd4db;
+    }
+
+    .btn-toolbar:hover {
+        border-color: #4a90e2;
+        color: #7db4ee;
+    }
+
+    .proxy-items {
+        background: rgba(255, 255, 255, 0.03);
+        border-color: rgba(255, 255, 255, 0.1);
+    }
+
+    .proxy-item {
+        border-bottom-color: rgba(255, 255, 255, 0.07);
+    }
+
+    .proxy-item:hover {
+        background: rgba(74, 144, 226, 0.12);
+    }
+
+    .proxy-addr {
+        color: #f0f0f0;
+    }
+
+    .proxy-slider {
+        background: #4a5058;
+    }
+
+    .proxy-del {
+        color: #7d838c;
+    }
+
+    .proxy-del:hover {
+        background: rgba(220, 53, 69, 0.2);
+        color: #ff6b7a;
+    }
+
+    .proxy-empty {
+        color: #8a929f;
+    }
 } 

--- a/web/static/css/status-card.css
+++ b/web/static/css/status-card.css
@@ -1076,13 +1076,19 @@
 
 .proxy-test {
     flex: 0 0 auto;
-    width: 30px;
+    min-width: 30px;
     height: 30px;
+    padding: 0 7px;
     border: none;
     border-radius: 6px;
     background: transparent;
     color: #8a93a0;
     cursor: pointer;
+    font-family: monospace;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 30px;
+    text-align: center;
     transition: all 0.2s ease;
 }
 
@@ -1097,9 +1103,29 @@
     cursor: wait;
 }
 
+/* 成功时显示延迟；由低到高使用绿/橙/红的颜色分级。 */
 .proxy-test.is-ok {
+    background: rgba(31, 157, 85, 0.12);
+}
+
+.proxy-test.is-latency-fast {
     color: #1f9d55;
     background: rgba(31, 157, 85, 0.12);
+}
+
+.proxy-test.is-latency-medium {
+    color: #d9822b;
+    background: rgba(217, 130, 43, 0.13);
+}
+
+.proxy-test.is-latency-slow {
+    color: #dc3545;
+    background: rgba(220, 53, 69, 0.12);
+}
+
+.proxy-test.is-latency-unknown {
+    color: #6c757d;
+    background: rgba(108, 117, 125, 0.12);
 }
 
 .proxy-test.is-ok:hover {
@@ -1297,8 +1323,22 @@
     }
 
     .proxy-test.is-ok {
+        background: rgba(31, 157, 85, 0.18);
+    }
+
+    .proxy-test.is-latency-fast {
         color: #3dd68c;
         background: rgba(31, 157, 85, 0.18);
+    }
+
+    .proxy-test.is-latency-medium {
+        color: #f0c36a;
+        background: rgba(230, 162, 60, 0.18);
+    }
+
+    .proxy-test.is-latency-slow {
+        color: #ff6b7a;
+        background: rgba(220, 53, 69, 0.18);
     }
 
     .proxy-test.is-fail {

--- a/web/static/css/status-card.css
+++ b/web/static/css/status-card.css
@@ -548,6 +548,52 @@
     font-size: 1rem;
 }
 
+.proxy-health-settings {
+    display: grid;
+    grid-template-columns: minmax(160px, 220px) auto minmax(180px, 240px) auto;
+    align-items: end;
+    gap: 12px 20px;
+    padding: 14px;
+    border: 1px solid rgba(74, 144, 226, 0.18);
+    border-radius: 10px;
+    background: rgba(74, 144, 226, 0.04);
+}
+
+.proxy-health-field .form-label {
+    margin-bottom: 5px;
+    font-size: 0.86rem;
+}
+
+.proxy-health-toggle {
+    padding-bottom: 8px;
+}
+
+.proxy-health-help {
+    margin-top: -8px;
+}
+
+.proxy-auto-check-status {
+    margin-top: 8px;
+    color: #4a90e2;
+    font-size: 0.84rem;
+}
+
+@media (max-width: 900px) {
+    .proxy-health-settings {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .proxy-health-settings {
+        grid-template-columns: 1fr;
+    }
+
+    .proxy-health-toggle {
+        padding-bottom: 0;
+    }
+}
+
 .proxy-actions .btn:disabled {
     opacity: 0.65;
     cursor: not-allowed;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1433,10 +1433,17 @@
                             <div class="proxy-lists">
                                 <div class="proxy-toolbar">
                                     <div class="proxy-count">
+                                        <label class="proxy-select-all" title="" id="proxy-select-all-label">
+                                            <input type="checkbox" id="proxy-select-all" onchange="toggleSelectAllProxies(this.checked)">
+                                            <span data-i18n="select_all_btn">全选</span>
+                                        </label>
+                                        <span class="proxy-count-sep">·</span>
                                         <i class="fa fa-list"></i>
                                         <span data-i18n="proxy_total_label">代理总数</span>：<span id="proxy-total">0</span>
                                         <span class="proxy-count-sep">·</span>
                                         <span data-i18n="proxy_enabled_label">已启用</span> <span id="proxy-enabled-count">0</span>
+                                        <span class="proxy-count-sep">·</span>
+                                        <span data-i18n="proxy_selected_label">已选中</span> <span id="proxy-selected-count">0</span>
                                     </div>
                                     <div class="proxy-toolbar-actions">
                                         <button type="button" class="btn btn-sm btn-toolbar" onclick="setAllProxies(true)">
@@ -1446,6 +1453,18 @@
                                         <button type="button" class="btn btn-sm btn-toolbar" onclick="setAllProxies(false)">
                                             <i class="fa fa-ban"></i>
                                             <span data-i18n="disable_all_btn">全部禁用</span>
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-toolbar" onclick="setSelectedProxies(true)">
+                                            <i class="fa fa-check-square-o"></i>
+                                            <span data-i18n="enable_selected_btn">启用选中</span>
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-toolbar" onclick="setSelectedProxies(false)">
+                                            <i class="fa fa-minus-square-o"></i>
+                                            <span data-i18n="disable_selected_btn">禁用选中</span>
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-toolbar btn-toolbar-danger" onclick="deleteSelectedProxies()">
+                                            <i class="fa fa-trash"></i>
+                                            <span data-i18n="delete_selected_btn">删除选中</span>
                                         </button>
                                     </div>
                                 </div>
@@ -1467,14 +1486,42 @@
                                 <div class="form-text" data-i18n="test_url_help">用于检测代理有效性的目标地址</div>
                             </div>
                             <div class="proxy-actions">
-                                <button class="btn btn-primary" onclick="saveProxies()">
-                                    <i class="fa fa-save"></i>
-                                    <span data-i18n="save_proxy_btn">保存代理</span>
-                                </button>
-                                <button class="btn btn-warning" onclick="checkProxies()">
+                                <button class="btn btn-warning" id="check-proxy-btn" onclick="checkProxies('enabled')">
                                     <i class="fa fa-check-circle"></i>
-                                    <span data-i18n="check_proxy_btn">检测代理</span>
+                                    <span data-i18n="check_proxy_btn">检测已启用</span>
                                 </button>
+                                <button class="btn btn-outline-warning" id="check-selected-btn" onclick="checkProxies('selected')">
+                                    <i class="fa fa-check-square-o"></i>
+                                    <span data-i18n="check_selected_btn">检测选中</span>
+                                </button>
+                                <button type="button" class="btn btn-secondary" id="check-pause-btn" onclick="pauseProxyCheck()" style="display:none;">
+                                    <i class="fa fa-pause"></i>
+                                    <span data-i18n="check_pause_btn">暂停</span>
+                                </button>
+                                <button type="button" class="btn btn-primary" id="check-resume-btn" onclick="resumeProxyCheck()" style="display:none;">
+                                    <i class="fa fa-play"></i>
+                                    <span data-i18n="check_resume_btn">继续</span>
+                                </button>
+                                <button type="button" class="btn btn-danger" id="check-stop-btn" onclick="stopProxyCheck()" style="display:none;">
+                                    <i class="fa fa-stop"></i>
+                                    <span data-i18n="check_stop_btn">停止</span>
+                                </button>
+                                <span id="check-progress" class="proxy-check-progress" aria-live="polite"></span>
+                            </div>
+                            <div class="proxy-check-log-panel">
+                                <div class="proxy-check-log-header">
+                                    <span>
+                                        <i class="fa fa-terminal"></i>
+                                        <span data-i18n="proxy_check_log_title">检测日志</span>
+                                    </span>
+                                    <button type="button" class="btn btn-sm btn-toolbar" onclick="clearProxyCheckLog()">
+                                        <i class="fa fa-trash"></i>
+                                        <span data-i18n="clear_check_log_btn">清空</span>
+                                    </button>
+                                </div>
+                                <div id="proxy-check-log" class="proxy-check-log" data-empty="1">
+                                    <div class="proxy-check-log-placeholder" data-i18n="proxy_check_log_empty">暂无检测记录</div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1724,32 +1771,120 @@
         }
 
         // ===== 代理管理：启用/禁用列表 =====
-        // 单一数据源：每项 { addr: '完整代理地址', enabled: 布尔值 }
+        // 单一数据源：每项 { addr, enabled, selected }
         let proxyItems = [];
+
+        // 协议别名 → 引擎标准协议（与后端 modules.PROXY_SCHEME_ALIASES 对齐）
+        const PROXY_SCHEME_ALIASES = {
+            'socks5h': 'socks5',
+            'socks5a': 'socks5',
+            'socks': 'socks5',
+            'socks4': 'socks5',
+            'socks4a': 'socks5',
+            'sock': 'socks5',
+            'http': 'http',
+            'https': 'https',
+            'socks5': 'socks5'
+        };
 
         function normalizeProxyAddr(raw) {
             let s = (raw || '').trim();
             if (s.startsWith('#')) s = s.replace(/^#+\s*/, '');
             if (!s) return '';
-            // 后端要求代理带 scheme://，无协议前缀时默认按 http:// 处理
+            // 无协议前缀时默认 http://
             if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(s)) s = 'http://' + s;
+            // 协议名小写 + 别名归并（socks5h → socks5 等）
+            s = s.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*/, m => {
+                const lower = m.toLowerCase();
+                return PROXY_SCHEME_ALIASES[lower] || lower;
+            });
             return s;
         }
 
+        // 与后端 validate_proxy_format 对齐
+        // 接受输入阶段的别名；normalize 后仅 http/https/socks5
+        // scheme://[user:pass@]host:port ，端口 1-65535
+        function isValidProxyFormat(addr) {
+            if (!addr) return false;
+            // 先规范化再校验，保证 socks5h 等能通过
+            const normalized = normalizeProxyAddr(addr);
+            const m = String(normalized).match(
+                /^(socks5|http|https):\/\/(?:([^@/\s]+)@)?(\[[^\]]+\]|[^:\/\s]+):(\d+)$/i
+            );
+            if (!m) return false;
+            const port = parseInt(m[4], 10);
+            return port > 0 && port < 65536;
+        }
+
         function proxyProtocol(addr) {
-            const m = (addr || '').match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-            return m ? m[1].toLowerCase() : 'http';
+            const normalized = normalizeProxyAddr(addr) || addr || '';
+            const m = normalized.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+            if (!m) return 'http';
+            const raw = m[1].toLowerCase();
+            return PROXY_SCHEME_ALIASES[raw] || raw;
+        }
+
+        function tProxy(key, fallback) {
+            return (translations[currentLanguage] && translations[currentLanguage][key]) || fallback;
+        }
+
+        // 持久化当前代理列表（已无独立“保存代理”按钮，增删改后自动调用）
+        function persistProxies(options = {}) {
+            const { successMessage = null, silent = false } = options;
+            const allProxies = proxyItems.map(item => item.enabled ? item.addr : '#' + item.addr);
+            const testEl = document.getElementById('test-target-url');
+            const testUrl = testEl ? testEl.value.trim() : '';
+
+            return $.ajax({
+                url: appendToken('/api/proxies'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ proxies: allProxies })
+            }).then(function(response) {
+                if (response && response.status === 'success') {
+                    if (testUrl) {
+                        $.ajax({
+                            url: appendToken('/api/config'),
+                            method: 'POST',
+                            contentType: 'application/json',
+                            data: JSON.stringify({ test_url: testUrl })
+                        });
+                    }
+                    if (successMessage) {
+                        showNotification(successMessage, 'success');
+                    } else if (!silent) {
+                        showNotification(tProxy('proxy_save_success', '代理保存成功'), 'success');
+                    }
+                    return response;
+                }
+                const msg = (response && response.message) || '';
+                showNotification(tProxy('proxy_save_failed', '代理保存失败: {}').replace('{}', msg), 'error');
+                return $.Deferred().reject(response).promise();
+            }, function(xhr) {
+                const msg = (xhr && xhr.responseText) || '';
+                showNotification(tProxy('proxy_save_failed', '代理保存失败: {}').replace('{}', msg), 'error');
+            });
         }
 
         function loadProxies() {
             $.get(appendToken('/api/proxies'), function(data) {
+                // 保留已有检测状态（按地址）
+                const prevStatus = {};
+                proxyItems.forEach(item => {
+                    if (item.addr && item.checkStatus) prevStatus[item.addr] = item.checkStatus;
+                });
                 proxyItems = (data.proxies || [])
                     .map(line => (line || '').trim())
                     .filter(line => line.length > 0)
-                    .map(line => ({
-                        enabled: !line.startsWith('#'),
-                        addr: normalizeProxyAddr(line)
-                    }))
+                    .map(line => {
+                        const addr = normalizeProxyAddr(line);
+                        return {
+                            enabled: !line.startsWith('#'),
+                            selected: false,
+                            addr,
+                            checkStatus: prevStatus[addr] || null // null | testing | ok | fail
+                        };
+                    })
                     .filter(item => item.addr);
                 renderProxyItems();
             });
@@ -1763,7 +1898,18 @@
             proxyItems.forEach((item, idx) => {
                 const proto = proxyProtocol(item.addr);
                 const row = document.createElement('div');
-                row.className = 'proxy-item' + (item.enabled ? '' : ' disabled');
+                row.className = 'proxy-item'
+                    + (item.enabled ? '' : ' disabled')
+                    + (item.selected ? ' selected' : '');
+                row.dataset.idx = String(idx);
+
+                const select = document.createElement('label');
+                select.className = 'proxy-select';
+                const selectCb = document.createElement('input');
+                selectCb.type = 'checkbox';
+                selectCb.checked = !!item.selected;
+                selectCb.addEventListener('change', () => toggleSelectProxy(idx, selectCb.checked));
+                select.appendChild(selectCb);
 
                 const sw = document.createElement('label');
                 sw.className = 'proxy-switch';
@@ -1785,16 +1931,35 @@
                 addr.textContent = item.addr;
                 addr.title = item.addr;
 
+                const testBtn = document.createElement('button');
+                testBtn.type = 'button';
+                testBtn.className = 'proxy-test' + (item.checkStatus ? ' is-' + item.checkStatus : '');
+                testBtn.title = tProxy('proxy_test_btn', '测试连通性');
+                testBtn.dataset.idx = String(idx);
+                if (item.checkStatus === 'testing') {
+                    testBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+                    testBtn.disabled = true;
+                } else if (item.checkStatus === 'ok') {
+                    testBtn.innerHTML = '<i class="fa fa-check"></i>';
+                } else if (item.checkStatus === 'fail') {
+                    testBtn.innerHTML = '<i class="fa fa-times"></i>';
+                } else {
+                    testBtn.innerHTML = '<i class="fa fa-plug"></i>';
+                }
+                testBtn.addEventListener('click', () => testSingleProxy(idx));
+
                 const del = document.createElement('button');
                 del.type = 'button';
                 del.className = 'proxy-del';
-                del.title = (translations[currentLanguage] && translations[currentLanguage].delete_btn) || '删除';
+                del.title = tProxy('delete_btn', '删除');
                 del.innerHTML = '<i class="fa fa-times"></i>';
                 del.addEventListener('click', () => deleteProxy(idx));
 
+                row.appendChild(select);
                 row.appendChild(sw);
                 row.appendChild(badge);
                 row.appendChild(addr);
+                row.appendChild(testBtn);
                 row.appendChild(del);
                 box.appendChild(row);
             });
@@ -1802,48 +1967,521 @@
             updateProxyCount();
         }
 
+        function updateProxyTestButton(idx) {
+            const item = proxyItems[idx];
+            if (!item) return;
+            const btn = document.querySelector(`.proxy-test[data-idx="${idx}"]`);
+            if (!btn) {
+                renderProxyItems();
+                return;
+            }
+            btn.className = 'proxy-test' + (item.checkStatus ? ' is-' + item.checkStatus : '');
+            btn.disabled = item.checkStatus === 'testing';
+            btn.title = tProxy('proxy_test_btn', '测试连通性');
+            if (item.checkStatus === 'testing') {
+                btn.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+            } else if (item.checkStatus === 'ok') {
+                btn.innerHTML = '<i class="fa fa-check"></i>';
+            } else if (item.checkStatus === 'fail') {
+                btn.innerHTML = '<i class="fa fa-times"></i>';
+            } else {
+                btn.innerHTML = '<i class="fa fa-plug"></i>';
+            }
+        }
+
+        function getProxyTestUrl() {
+            const el = document.getElementById('test-target-url');
+            return ((el && el.value) || '').trim() || 'https://www.baidu.com';
+        }
+
+        function appendProxyCheckLog(message, level) {
+            const box = document.getElementById('proxy-check-log');
+            if (!box) return;
+            if (box.dataset.empty === '1' || box.querySelector('.proxy-check-log-placeholder')) {
+                box.innerHTML = '';
+                box.dataset.empty = '0';
+            }
+            const time = new Date().toLocaleTimeString();
+            const line = document.createElement('div');
+            line.className = 'proxy-check-log-line' + (level ? ' is-' + level : '');
+            line.innerHTML = `<span class="proxy-check-log-time">${time}</span><span class="proxy-check-log-msg"></span>`;
+            line.querySelector('.proxy-check-log-msg').textContent = message;
+            box.appendChild(line);
+            box.scrollTop = box.scrollHeight;
+        }
+
+        function clearProxyCheckLog() {
+            const box = document.getElementById('proxy-check-log');
+            if (!box) return;
+            box.innerHTML = `<div class="proxy-check-log-placeholder">${tProxy('proxy_check_log_empty', '暂无检测记录')}</div>`;
+            box.dataset.empty = '1';
+        }
+
+        function requestCheckProxy(addr, testUrl) {
+            const xhr = $.ajax({
+                url: appendToken('/api/check_proxy'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    proxy: addr,
+                    test_url: testUrl,
+                    force: true
+                })
+            });
+            // 供批量检测停止时 abort
+            proxyCheckCtl.currentXhr = xhr;
+            return xhr.always(function() {
+                if (proxyCheckCtl.currentXhr === xhr) {
+                    proxyCheckCtl.currentXhr = null;
+                }
+            });
+        }
+
+        function formatCheckResultLog(addr, data, ok) {
+            const ms = (data && data.elapsed_ms != null) ? ` [${data.elapsed_ms}ms]` : '';
+            const err = (!ok && data && data.error) ? ` — ${data.error}` : '';
+            const base = ok
+                ? tProxy('proxy_check_item_ok', '成功：{}')
+                : tProxy('proxy_check_item_fail', '失败：{}');
+            return base.replace('{}', addr) + ms + err;
+        }
+
+        function testSingleProxy(idx) {
+            const item = proxyItems[idx];
+            if (!item || item.checkStatus === 'testing') return;
+            // 批量检测进行中时，不允许打断式单测（避免状态错乱）
+            if (proxyCheckCtl.running) {
+                showNotification(tProxy('check_busy', '批量检测进行中，请先暂停/停止'), 'info');
+                return;
+            }
+
+            const testUrl = getProxyTestUrl();
+            item.checkStatus = 'testing';
+            updateProxyTestButton(idx);
+            appendProxyCheckLog(
+                tProxy('proxy_check_item_testing', '检测中：{}').replace('{}', item.addr),
+                'info'
+            );
+
+            requestCheckProxy(item.addr, testUrl)
+                .done(function(data) {
+                    const ok = !!(data && data.status === 'success' && data.valid);
+                    item.checkStatus = ok ? 'ok' : 'fail';
+                    updateProxyTestButton(idx);
+                    appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
+                })
+                .fail(function(xhr) {
+                    item.checkStatus = 'fail';
+                    updateProxyTestButton(idx);
+                    let err = '';
+                    try {
+                        const body = xhr && xhr.responseJSON;
+                        err = (body && (body.error || body.message)) || (xhr && xhr.responseText) || '';
+                    } catch (e) {
+                        err = (xhr && xhr.responseText) || '';
+                    }
+                    appendProxyCheckLog(
+                        tProxy('proxy_check_item_fail', '失败：{}').replace('{}', item.addr)
+                            + (err ? ' — ' + err : ''),
+                        'fail'
+                    );
+                });
+        }
+
+        // 批量检测控制：运行 / 暂停 / 停止
+        const proxyCheckCtl = {
+            running: false,
+            paused: false,
+            stopRequested: false,
+            currentXhr: null,
+            total: 0,
+            done: 0,
+            okCount: 0,
+            failCount: 0,
+        };
+
+        function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        function setCheckControlState(state) {
+            // state: idle | running | paused
+            const startBtn = document.getElementById('check-proxy-btn');
+            const pauseBtn = document.getElementById('check-pause-btn');
+            const resumeBtn = document.getElementById('check-resume-btn');
+            const stopBtn = document.getElementById('check-stop-btn');
+            const progress = document.getElementById('check-progress');
+
+            const show = (el, on) => { if (el) el.style.display = on ? '' : 'none'; };
+
+            if (state === 'idle') {
+                if (startBtn) {
+                    startBtn.disabled = false;
+                    startBtn.innerHTML = `<i class="fa fa-check-circle"></i> <span>${tProxy('check_proxy_btn', '检测已启用')}</span>`;
+                }
+                show(pauseBtn, false);
+                show(resumeBtn, false);
+                show(stopBtn, false);
+                if (progress) progress.textContent = '';
+            } else if (state === 'running') {
+                if (startBtn) {
+                    startBtn.disabled = true;
+                    startBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> <span>${tProxy('checking_proxy', '检测中...')}</span>`;
+                }
+                show(pauseBtn, true);
+                show(resumeBtn, false);
+                show(stopBtn, true);
+                if (pauseBtn) pauseBtn.disabled = false;
+                if (stopBtn) stopBtn.disabled = false;
+            } else if (state === 'paused') {
+                if (startBtn) {
+                    startBtn.disabled = true;
+                    startBtn.innerHTML = `<i class="fa fa-pause"></i> <span>${tProxy('check_paused_label', '已暂停')}</span>`;
+                }
+                show(pauseBtn, false);
+                show(resumeBtn, true);
+                show(stopBtn, true);
+                if (resumeBtn) resumeBtn.disabled = false;
+                if (stopBtn) stopBtn.disabled = false;
+            }
+            updateCheckProgress();
+        }
+
+        function updateCheckProgress() {
+            const progress = document.getElementById('check-progress');
+            if (!progress) return;
+            if (!proxyCheckCtl.running || !proxyCheckCtl.total) {
+                if (!proxyCheckCtl.running) progress.textContent = '';
+                return;
+            }
+            const extra = proxyCheckCtl.paused
+                ? ` · ${tProxy('check_paused_label', '已暂停')}`
+                : '';
+            progress.textContent = tProxy('check_progress_text', '进度 {}/{}（成功 {} / 失败 {}）')
+                .replace('{}', proxyCheckCtl.done)
+                .replace('{}', proxyCheckCtl.total)
+                .replace('{}', proxyCheckCtl.okCount)
+                .replace('{}', proxyCheckCtl.failCount) + extra;
+        }
+
+        async function waitWhilePausedOrStopped() {
+            while (proxyCheckCtl.paused && !proxyCheckCtl.stopRequested) {
+                await sleep(200);
+            }
+            return !proxyCheckCtl.stopRequested;
+        }
+
+        function pauseProxyCheck() {
+            if (!proxyCheckCtl.running || proxyCheckCtl.paused) return;
+            proxyCheckCtl.paused = true;
+            setCheckControlState('paused');
+            appendProxyCheckLog(tProxy('check_paused_log', '检测已暂停'), 'info');
+        }
+
+        function resumeProxyCheck() {
+            if (!proxyCheckCtl.running || !proxyCheckCtl.paused) return;
+            proxyCheckCtl.paused = false;
+            setCheckControlState('running');
+            appendProxyCheckLog(tProxy('check_resumed_log', '检测已继续'), 'info');
+        }
+
+        function stopProxyCheck() {
+            if (!proxyCheckCtl.running) return;
+            proxyCheckCtl.stopRequested = true;
+            proxyCheckCtl.paused = false; // 解除暂停等待
+            // 中断当前正在进行的请求
+            if (proxyCheckCtl.currentXhr && typeof proxyCheckCtl.currentXhr.abort === 'function') {
+                try { proxyCheckCtl.currentXhr.abort(); } catch (e) { /* ignore */ }
+            }
+            const stopBtn = document.getElementById('check-stop-btn');
+            const pauseBtn = document.getElementById('check-pause-btn');
+            const resumeBtn = document.getElementById('check-resume-btn');
+            if (stopBtn) stopBtn.disabled = true;
+            if (pauseBtn) pauseBtn.disabled = true;
+            if (resumeBtn) resumeBtn.disabled = true;
+            appendProxyCheckLog(tProxy('check_stop_requested_log', '正在停止检测…'), 'info');
+        }
+
+        async function checkProxies(mode) {
+            if (proxyCheckCtl.running) return;
+
+            mode = mode || 'enabled';
+
+            // 以地址为键重新解析 idx，避免 render 后索引漂移
+            let items = proxyItems
+                .map((item, idx) => ({ item, idx, addr: item.addr }));
+
+            if (mode === 'selected') {
+                items = items.filter(x => x.item.selected);
+            } else {
+                items = items.filter(x => x.item.enabled);
+            }
+
+            if (!items.length) {
+                const key = mode === 'selected' ? 'proxy_check_none_selected' : 'proxy_check_none_enabled';
+                showNotification(tProxy(key, '没有可检测的代理'), 'info');
+                appendProxyCheckLog(tProxy(key, '没有可检测的代理'), 'info');
+                return;
+            }
+
+            const testUrl = getProxyTestUrl();
+
+            proxyCheckCtl.running = true;
+            proxyCheckCtl.paused = false;
+            proxyCheckCtl.stopRequested = false;
+            proxyCheckCtl.total = items.length;
+            proxyCheckCtl.done = 0;
+            proxyCheckCtl.okCount = 0;
+            proxyCheckCtl.failCount = 0;
+            setCheckControlState('running');
+
+            // 记住测试目标
+            $.ajax({
+                url: appendToken('/api/config'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ test_url: testUrl })
+            });
+
+            const startMsg = mode === 'selected'
+                ? tProxy('proxy_check_start_selected', '开始检测 {} 个选中代理…')
+                : tProxy('proxy_check_start', '开始检测 {} 个已启用代理…');
+            appendProxyCheckLog(startMsg.replace('{}', items.length), 'info');
+
+            let stopped = false;
+
+            for (let i = 0; i < items.length; i++) {
+                if (proxyCheckCtl.stopRequested) {
+                    stopped = true;
+                    break;
+                }
+                const cont = await waitWhilePausedOrStopped();
+                if (!cont) {
+                    stopped = true;
+                    break;
+                }
+
+                // 根据地址重新定位，防止中途列表变更
+                const addr = items[i].addr;
+                let idx = proxyItems.findIndex(x => x.addr === addr);
+                if (idx < 0) {
+                    proxyCheckCtl.done++;
+                    updateCheckProgress();
+                    continue;
+                }
+                const item = proxyItems[idx];
+
+                item.checkStatus = 'testing';
+                updateProxyTestButton(idx);
+                appendProxyCheckLog(
+                    tProxy('proxy_check_item_testing', '检测中：{}').replace('{}', item.addr)
+                        + ` (${i + 1}/${items.length})`,
+                    'info'
+                );
+                updateCheckProgress();
+
+                try {
+                    const data = await requestCheckProxy(item.addr, testUrl);
+                    if (proxyCheckCtl.stopRequested) {
+                        // 停止时若请求已返回，仍记录结果
+                        const ok = !!(data && data.status === 'success' && data.valid);
+                        item.checkStatus = ok ? 'ok' : 'fail';
+                        if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
+                        updateProxyTestButton(idx);
+                        appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
+                        proxyCheckCtl.done++;
+                        stopped = true;
+                        break;
+                    }
+                    const ok = !!(data && data.status === 'success' && data.valid);
+                    item.checkStatus = ok ? 'ok' : 'fail';
+                    if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
+                    updateProxyTestButton(idx);
+                    appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
+                } catch (e) {
+                    const aborted = proxyCheckCtl.stopRequested
+                        || (e && (e.statusText === 'abort' || e.status === 0 && proxyCheckCtl.stopRequested));
+                    if (aborted) {
+                        // 当前条被中止：恢复为未检测，不计入失败
+                        item.checkStatus = null;
+                        updateProxyTestButton(idx);
+                        appendProxyCheckLog(
+                            tProxy('check_item_aborted', '已中止：{}').replace('{}', item.addr),
+                            'info'
+                        );
+                        stopped = true;
+                        break;
+                    }
+                    item.checkStatus = 'fail';
+                    proxyCheckCtl.failCount++;
+                    updateProxyTestButton(idx);
+                    appendProxyCheckLog(
+                        tProxy('proxy_check_item_fail', '失败：{}').replace('{}', item.addr)
+                            + (e && e.message ? ' — ' + e.message : ''),
+                        'fail'
+                    );
+                }
+
+                proxyCheckCtl.done++;
+                updateCheckProgress();
+            }
+
+            const okCount = proxyCheckCtl.okCount;
+            const failCount = proxyCheckCtl.failCount;
+            const checked = proxyCheckCtl.done;
+            const total = proxyCheckCtl.total;
+
+            if (stopped || proxyCheckCtl.stopRequested) {
+                const msg = tProxy('check_stopped_log', '检测已停止：已测 {}/{}（成功 {} / 失败 {}）')
+                    .replace('{}', checked)
+                    .replace('{}', total)
+                    .replace('{}', okCount)
+                    .replace('{}', failCount);
+                appendProxyCheckLog(msg, 'info');
+                showNotification(msg, 'info');
+            } else {
+                const msg = tProxy('proxy_check_done', '检测完成：成功 {} / 失败 {} / 共 {}')
+                    .replace('{}', okCount)
+                    .replace('{}', failCount)
+                    .replace('{}', total);
+                appendProxyCheckLog(msg, 'info');
+                showNotification(msg, failCount ? 'info' : 'success');
+            }
+
+            proxyCheckCtl.running = false;
+            proxyCheckCtl.paused = false;
+            proxyCheckCtl.stopRequested = false;
+            proxyCheckCtl.currentXhr = null;
+            setCheckControlState('idle');
+        }
+
         function updateProxyCount() {
             const total = document.getElementById('proxy-total');
             const enabled = document.getElementById('proxy-enabled-count');
+            const selected = document.getElementById('proxy-selected-count');
+            const selectedCount = proxyItems.filter(x => x.selected).length;
             if (total) total.textContent = proxyItems.length;
             if (enabled) enabled.textContent = proxyItems.filter(x => x.enabled).length;
+            if (selected) selected.textContent = selectedCount;
+
+            const selectAll = document.getElementById('proxy-select-all');
+            if (selectAll) {
+                const allSelected = proxyItems.length > 0 && selectedCount === proxyItems.length;
+                const someSelected = selectedCount > 0 && selectedCount < proxyItems.length;
+                selectAll.checked = allSelected;
+                selectAll.indeterminate = someSelected;
+            }
         }
 
         function toggleProxy(idx) {
             if (!proxyItems[idx]) return;
             proxyItems[idx].enabled = !proxyItems[idx].enabled;
             renderProxyItems();
+            persistProxies({ silent: true });
+        }
+
+        function toggleSelectProxy(idx, selected) {
+            if (!proxyItems[idx]) return;
+            proxyItems[idx].selected = !!selected;
+            renderProxyItems();
+        }
+
+        function toggleSelectAllProxies(selected) {
+            proxyItems.forEach(x => x.selected = !!selected);
+            renderProxyItems();
         }
 
         function deleteProxy(idx) {
             proxyItems.splice(idx, 1);
             renderProxyItems();
+            persistProxies({ silent: true });
+        }
+
+        function deleteSelectedProxies() {
+            const count = proxyItems.filter(x => x.selected).length;
+            if (count === 0) {
+                showNotification(tProxy('proxy_delete_none', '请先勾选要删除的代理'), 'info');
+                return;
+            }
+            const msg = tProxy('confirm_delete_selected', '确定删除选中的 {} 个代理吗？').replace('{}', count);
+            if (!confirm(msg)) return;
+            proxyItems = proxyItems.filter(x => !x.selected);
+            renderProxyItems();
+            persistProxies({
+                successMessage: tProxy('proxy_deleted', '已删除 {} 个代理').replace('{}', count)
+            });
         }
 
         function setAllProxies(enabled) {
             proxyItems.forEach(x => x.enabled = enabled);
             renderProxyItems();
+            persistProxies({ silent: true });
+        }
+
+        function setSelectedProxies(enabled) {
+            const selected = proxyItems.filter(x => x.selected);
+            if (!selected.length) {
+                showNotification(tProxy('proxy_select_none', '请先勾选要操作的代理'), 'info');
+                return;
+            }
+            selected.forEach(x => x.enabled = !!enabled);
+            renderProxyItems();
+            const msg = enabled
+                ? tProxy('proxy_enable_selected', '已启用选中的 {} 个代理').replace('{}', selected.length)
+                : tProxy('proxy_disable_selected', '已禁用选中的 {} 个代理').replace('{}', selected.length);
+            persistProxies({ successMessage: msg });
         }
 
         function addProxies() {
             const ta = document.getElementById('proxy-add-input');
             if (!ta) return;
-            const lines = ta.value.split('\n').map(s => s.trim()).filter(Boolean);
+            const rawLines = ta.value.split('\n');
+            const remaining = [];
+            const invalid = [];
             let added = 0;
-            lines.forEach(line => {
+
+            rawLines.forEach(rawLine => {
+                const line = rawLine.trim();
+                if (!line) return;
+
                 const enabled = !line.startsWith('#');
                 const addr = normalizeProxyAddr(line);
-                if (!addr) return;
-                if (proxyItems.some(x => x.addr === addr)) return; // 去重，避免重复添加
-                proxyItems.push({ addr, enabled });
+
+                if (!addr || !isValidProxyFormat(addr)) {
+                    invalid.push(line);
+                    remaining.push(rawLine);
+                    return;
+                }
+
+                // 去重：已存在的有效行直接丢弃，不回填输入框
+                if (proxyItems.some(x => x.addr === addr)) return;
+
+                proxyItems.push({ addr, enabled, selected: false, checkStatus: null });
                 added++;
             });
-            ta.value = '';
+
+            // 无效行保留在输入框，方便用户修改后重试
+            ta.value = remaining.join('\n');
             renderProxyItems();
+
+            if (invalid.length > 0) {
+                const preview = invalid.slice(0, 5).join(', ') + (invalid.length > 5 ? ' ...' : '');
+                showNotification(
+                    tProxy('proxy_format_invalid', '格式无效未导入：{}').replace('{}', preview),
+                    'error'
+                );
+            }
+
             if (added > 0) {
-                showNotification(((translations[currentLanguage] && translations[currentLanguage].proxy_added) || '已添加 {} 个代理').replace('{}', added), 'success');
-            } else {
-                showNotification((translations[currentLanguage] && translations[currentLanguage].proxy_add_none) || '没有可添加的新代理', 'info');
+                const btn = document.querySelector('.proxy-add-btn');
+                if (btn) btn.disabled = true;
+                persistProxies({
+                    successMessage: tProxy('proxy_add_saved', '已添加并保存 {} 个代理').replace('{}', added)
+                }).always(function() {
+                    if (btn) btn.disabled = false;
+                });
+            } else if (invalid.length === 0) {
+                showNotification(tProxy('proxy_add_none', '没有可添加的新代理'), 'info');
             }
         }
 
@@ -1891,75 +2529,10 @@
         function switchProxy() {
             $.get(appendToken('/api/switch_proxy'), function(data) {
                 if (data.status === 'success') {
-                    updateStatus(); 
+                    updateStatus();
                 } else {
                     console.error('Failed to switch proxy:', data.message);
                 }
-            });
-        }
-
-        function saveProxies() {
-            // 从统一列表构建；禁用项写为以 # 开头的注释行，后端加载时会跳过
-            const allProxies = proxyItems.map(item => item.enabled ? item.addr : '#' + item.addr);
-
-            // 获取测试URL
-            const testUrl = document.getElementById('test-target-url').value.trim();
-            
-            // 首先更新配置
-            $.ajax({
-                url: appendToken('/api/config'),
-                method: 'POST',
-                contentType: 'application/json',
-                data: JSON.stringify({ test_url: testUrl }),
-                success: function(configResponse) {
-                    // 然后保存代理列表
-                    $.ajax({
-                        url: appendToken('/api/proxies'),
-                        method: 'POST',
-                        contentType: 'application/json',
-                        data: JSON.stringify({ proxies: allProxies }),
-                        success: function(response) {
-                            if (response.status === 'success' && configResponse.status === 'success') {
-                                showNotification(translations[currentLanguage].proxy_save_success, 'success');
-                                // 重新加载代理列表以确保显示正确
-                                loadProxies();
-                            } else {
-                                showNotification(translations[currentLanguage].proxy_save_failed.format(response.message), 'error');
-                            }
-                        },
-                        error: function(xhr) {
-                            showNotification(translations[currentLanguage].proxy_save_failed.format(xhr.responseText), 'error');
-                        }
-                    });
-                },
-                error: function(xhr) {
-                    showNotification(translations[currentLanguage].config_save_failed.format(xhr.responseText), 'error');
-                }
-            });
-        }
-
-        function checkProxies() {
-            const testUrl = $('#test-target-url').val().trim() || 'https://www.baidu.com';
-            
-            // 显示加载状态
-            const saveBtn = document.querySelector('.proxy-actions .btn-primary');
-            const checkBtn = document.querySelector('.proxy-actions .btn-warning');
-            saveBtn.disabled = true;
-            checkBtn.disabled = true;
-            checkBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> ${translations[currentLanguage].checking_proxy}`;
-            
-            $.get(appendToken('/api/check_proxies'), { test_url: testUrl }, function(data) {
-                if (data.status === 'success') {
-                    loadProxies();
-                    showNotification(translations[currentLanguage].proxy_check_result.replace('{}', data.total), 'success');
-                } else {
-                    showNotification(translations[currentLanguage].proxy_check_failed.format(data.message), 'error');
-                }
-            }).always(function() {
-                // 恢复按钮状态
-                saveBtn.disabled = false;
-                checkBtn.disabled = false;
-                checkBtn.innerHTML = `<i class="fa fa-check-circle"></i> <span>${translations[currentLanguage].check_proxy_btn}</span>`;
             });
         }
 
@@ -2278,8 +2851,7 @@
                 'api_url_label': 'API地址',
                 'enable_proxy_check_label': '代理有效性检测',
                 'proxy_list_label': '代理列表',
-                'save_proxy_btn': '保存代理',
-                'check_proxy_btn': '检测代理',
+                'check_proxy_btn': '检测已启用',
                 'whitelist_title': '白名单',
                 'blacklist_title': '黑名单',
                 'ip_auth_priority_label': 'IP认证优先级',
@@ -2405,19 +2977,56 @@
                 'proxy_total_label': '代理总数',
                 'proxy_enabled_label': '已启用',
                 'proxy_disabled_label': '已禁用',
+                'proxy_selected_label': '已选中',
+                'select_all_btn': '全选',
                 'enable_all_btn': '全部启用',
                 'disable_all_btn': '全部禁用',
+                'enable_selected_btn': '启用选中',
+                'disable_selected_btn': '禁用选中',
+                'delete_selected_btn': '删除选中',
+                'proxy_select_none': '请先勾选要操作的代理',
+                'proxy_enable_selected': '已启用选中的 {} 个代理',
+                'proxy_disable_selected': '已禁用选中的 {} 个代理',
                 'add_proxy_btn': '添加代理',
                 'delete_btn': '删除',
+                'confirm_delete_selected': '确定删除选中的 {} 个代理吗？',
+                'proxy_deleted': '已删除 {} 个代理',
+                'proxy_delete_none': '请先勾选要删除的代理',
                 'proxy_empty_hint': '暂无代理，请在下方添加',
-                'proxy_add_placeholder': '每行一个：ip:port 或 protocol://[user:pass@]ip:port\n例如：http://user:pass@127.0.0.1:8080',
+                'proxy_add_placeholder': '每行一个：ip:port 或 protocol://[user:pass@]ip:port\n支持 http/https/socks5/socks5h\n例如：socks5h://user:pass@host:11080',
                 'proxy_added': '已添加 {} 个代理',
+                'proxy_add_saved': '已添加并保存 {} 个代理',
                 'proxy_add_none': '没有可添加的新代理',
-                'save_proxy_btn': '保存代理',
-                'check_proxy_btn': '检测代理',
+                'proxy_format_invalid': '格式无效未导入：{}',
+                'check_proxy_btn': '检测已启用',
+                'check_selected_btn': '检测选中',
                 'checking_proxy': '检测中...',
+                'check_pause_btn': '暂停',
+                'check_resume_btn': '继续',
+                'check_stop_btn': '停止',
+                'check_paused_label': '已暂停',
+                'check_paused_log': '检测已暂停',
+                'check_resumed_log': '检测已继续',
+                'check_stop_requested_log': '正在停止检测…',
+                'check_stopped_log': '检测已停止：已测 {}/{}（成功 {} / 失败 {}）',
+                'check_item_aborted': '已中止：{}',
+                'check_progress_text': '进度 {}/{}（成功 {} / 失败 {}）',
+                'check_busy': '批量检测进行中，请先暂停/停止',
+                'proxy_test_btn': '测试连通性',
+                'proxy_check_log_title': '检测日志',
+                'clear_check_log_btn': '清空',
+                'proxy_check_log_empty': '暂无检测记录',
+                'proxy_check_none_enabled': '没有已启用的代理可检测',
+                'proxy_check_start': '开始检测 {} 个已启用代理…',
+                'proxy_check_start_selected': '开始检测 {} 个选中代理…',
+                'proxy_check_none_selected': '没有已选中的代理可检测',
+                'proxy_check_item_testing': '检测中：{}',
+                'proxy_check_item_ok': '成功：{}',
+                'proxy_check_item_fail': '失败：{}',
+                'proxy_check_done': '检测完成：成功 {} / 失败 {} / 共 {}',
                 'proxy_check_success': '代理检测完成，有效代理数：{}',
                 'proxy_check_failed': '代理检测失败：{}',
+                'proxy_check_result': '代理检测完成，有效代理数：{}',
                 'version_text': '当前版本:',
                 'latest_version': '已是最新版本',
                 'new_version_available': '发现新版本',
@@ -2517,8 +3126,7 @@
                 'api_url_label': 'API URL',
                 'enable_proxy_check_label': 'Proxy Validity Check',
                 'proxy_list_label': 'Proxy List',
-                'save_proxy_btn': 'Save Proxies',
-                'check_proxy_btn': 'Check Proxies',
+                'check_proxy_btn': 'Check Enabled',
                 'whitelist_title': 'Whitelist',
                 'blacklist_title': 'Blacklist',
                 'ip_auth_priority_label': 'IP Auth Priority',
@@ -2624,19 +3232,56 @@
                 'proxy_total_label': 'Total',
                 'proxy_enabled_label': 'Enabled',
                 'proxy_disabled_label': 'Disabled',
+                'proxy_selected_label': 'Selected',
+                'select_all_btn': 'Select All',
                 'enable_all_btn': 'Enable All',
                 'disable_all_btn': 'Disable All',
+                'enable_selected_btn': 'Enable Selected',
+                'disable_selected_btn': 'Disable Selected',
+                'delete_selected_btn': 'Delete Selected',
+                'proxy_select_none': 'Select proxies first',
+                'proxy_enable_selected': 'Enabled {} selected proxy(ies)',
+                'proxy_disable_selected': 'Disabled {} selected proxy(ies)',
                 'add_proxy_btn': 'Add Proxy',
                 'delete_btn': 'Delete',
+                'confirm_delete_selected': 'Delete {} selected proxy(ies)?',
+                'proxy_deleted': 'Deleted {} proxy(ies)',
+                'proxy_delete_none': 'Select proxies to delete first',
                 'proxy_empty_hint': 'No proxies yet. Add some below.',
-                'proxy_add_placeholder': 'One per line: ip:port or protocol://[user:pass@]ip:port\nExample: http://user:pass@127.0.0.1:8080',
+                'proxy_add_placeholder': 'One per line: ip:port or protocol://[user:pass@]ip:port\nSupports http/https/socks5/socks5h\nExample: socks5h://user:pass@host:11080',
                 'proxy_added': 'Added {} proxy(ies)',
+                'proxy_add_saved': 'Added and saved {} proxy(ies)',
                 'proxy_add_none': 'No new proxies to add',
-                'save_proxy_btn': 'Save Proxies',
-                'check_proxy_btn': 'Check Proxies',
+                'proxy_format_invalid': 'Invalid format, skipped: {}',
+                'check_proxy_btn': 'Check Enabled',
+                'check_selected_btn': 'Check Selected',
                 'checking_proxy': 'Checking...',
+                'check_pause_btn': 'Pause',
+                'check_resume_btn': 'Resume',
+                'check_stop_btn': 'Stop',
+                'check_paused_label': 'Paused',
+                'check_paused_log': 'Check paused',
+                'check_resumed_log': 'Check resumed',
+                'check_stop_requested_log': 'Stopping check…',
+                'check_stopped_log': 'Check stopped: done {}/{} (OK {} / FAIL {})',
+                'check_item_aborted': 'Aborted: {}',
+                'check_progress_text': 'Progress {}/{} (OK {} / FAIL {})',
+                'check_busy': 'Bulk check in progress — pause/stop first',
+                'proxy_test_btn': 'Test connectivity',
+                'proxy_check_log_title': 'Check Log',
+                'clear_check_log_btn': 'Clear',
+                'proxy_check_log_empty': 'No check records yet',
+                'proxy_check_none_enabled': 'No enabled proxies to check',
+                'proxy_check_start': 'Checking {} enabled proxy(ies)…',
+                'proxy_check_start_selected': 'Checking {} selected proxy(ies)…',
+                'proxy_check_none_selected': 'No selected proxies to check',
+                'proxy_check_item_testing': 'Testing: {}',
+                'proxy_check_item_ok': 'OK: {}',
+                'proxy_check_item_fail': 'FAIL: {}',
+                'proxy_check_done': 'Done: OK {} / FAIL {} / Total {}',
                 'proxy_check_success': 'Proxy check completed, valid proxies: {}',
                 'proxy_check_failed': 'Proxy check failed: {}',
+                'proxy_check_result': 'Proxy check completed, valid proxies: {}',
                 'version_text': 'Current Version:',
                 'latest_version': 'Up to date',
                 'new_version_available': 'New version available',
@@ -2674,11 +3319,8 @@
             renderProxyItems();
 
             // 更新按钮文本
-            const saveBtn = document.querySelector('.proxy-actions .btn-primary span');
-            const checkBtn = document.querySelector('.proxy-actions .btn-warning span');
-            if (saveBtn) {
-                saveBtn.textContent = translations[language].save_proxy_btn;
-            }
+            const checkBtn = document.querySelector('#check-proxy-btn span')
+                || document.querySelector('.proxy-actions .btn-warning span');
             if (checkBtn) {
                 checkBtn.textContent = translations[language].check_proxy_btn;
             }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1431,48 +1431,34 @@
                         </h5>
                         <div class="proxy-management">
                             <div class="proxy-lists">
-                                <div class="row">
-                                    <div class="col-md-4">
-                                        <div class="proxy-list-section">
-                                            <div class="proxy-list-header">
-                                                <i class="fa fa-globe"></i>
-                                                <span>HTTP代理</span>
-                                            </div>
-                                            <textarea class="form-control" id="http-proxy-list" rows="8" 
-                                                placeholder="每行一个地址，格式：ip:port&#10;例如：127.0.0.1:8080"></textarea>
-                                        </div>
+                                <div class="proxy-toolbar">
+                                    <div class="proxy-count">
+                                        <i class="fa fa-list"></i>
+                                        <span data-i18n="proxy_total_label">代理总数</span>：<span id="proxy-total">0</span>
+                                        <span class="proxy-count-sep">·</span>
+                                        <span data-i18n="proxy_enabled_label">已启用</span> <span id="proxy-enabled-count">0</span>
                                     </div>
-                                    <div class="col-md-4">
-                                        <div class="proxy-list-section">
-                                            <div class="proxy-list-header">
-                                                <i class="fa fa-lock"></i>
-                                                <span>HTTPS代理</span>
-                                            </div>
-                                            <textarea class="form-control" id="https-proxy-list" rows="8"
-                                                placeholder="每行一个地址，格式：ip:port&#10;例如：127.0.0.1:8443"></textarea>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-4">
-                                        <div class="proxy-list-section">
-                                            <div class="proxy-list-header">
-                                                <i class="fa fa-shield"></i>
-                                                <span>SOCKS5代理</span>
-                                            </div>
-                                            <textarea class="form-control" id="socks5-proxy-list" rows="8"
-                                                placeholder="每行一个地址，格式：ip:port&#10;例如：127.0.0.1:1080"></textarea>
-                                        </div>
+                                    <div class="proxy-toolbar-actions">
+                                        <button type="button" class="btn btn-sm btn-toolbar" onclick="setAllProxies(true)">
+                                            <i class="fa fa-check-circle"></i>
+                                            <span data-i18n="enable_all_btn">全部启用</span>
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-toolbar" onclick="setAllProxies(false)">
+                                            <i class="fa fa-ban"></i>
+                                            <span data-i18n="disable_all_btn">全部禁用</span>
+                                        </button>
                                     </div>
                                 </div>
-                                <div class="mt-4">
-                                    <div class="proxy-list-section">
-                                        <div class="proxy-list-header">
-                                            <i class="fa fa-code"></i>
-                                            <span data-i18n="full_proxy">完整代理地址</span>
-                                            <div class="proxy-list-help" data-i18n="proxy_help">支持完整格式的代理地址，包含协议和认证信息</div>
-                                        </div>
-                                        <textarea class="form-control" id="full-proxy-list" rows="4"
-                                            placeholder="每行一个地址，格式：protocol://[username:password@]ip:port&#10;例如：http://user:pass@127.0.0.1:8080"></textarea>
-                                    </div>
+                                <div id="proxy-items" class="proxy-items"></div>
+                                <div id="proxy-empty" class="proxy-empty" data-i18n="proxy_empty_hint">暂无代理，请在下方添加</div>
+                                <div class="proxy-add">
+                                    <textarea class="form-control" id="proxy-add-input" rows="3"
+                                        data-i18n-placeholder="proxy_add_placeholder"
+                                        placeholder="每行一个：ip:port 或 protocol://[user:pass@]ip:port&#10;例如：http://user:pass@127.0.0.1:8080"></textarea>
+                                    <button type="button" class="btn btn-secondary proxy-add-btn" onclick="addProxies()">
+                                        <i class="fa fa-plus"></i>
+                                        <span data-i18n="add_proxy_btn">添加代理</span>
+                                    </button>
                                 </div>
                             </div>
                             <div class="mb-3 mt-4">
@@ -1737,38 +1723,128 @@
             });
         }
 
+        // ===== 代理管理：启用/禁用列表 =====
+        // 单一数据源：每项 { addr: '完整代理地址', enabled: 布尔值 }
+        let proxyItems = [];
+
+        function normalizeProxyAddr(raw) {
+            let s = (raw || '').trim();
+            if (s.startsWith('#')) s = s.replace(/^#+\s*/, '');
+            if (!s) return '';
+            // 后端要求代理带 scheme://，无协议前缀时默认按 http:// 处理
+            if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(s)) s = 'http://' + s;
+            return s;
+        }
+
+        function proxyProtocol(addr) {
+            const m = (addr || '').match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+            return m ? m[1].toLowerCase() : 'http';
+        }
+
         function loadProxies() {
             $.get(appendToken('/api/proxies'), function(data) {
-                const httpProxies = [];
-                const httpsProxies = [];
-                const socks5Proxies = [];
-                const fullProxies = [];
-                
-                data.proxies.forEach(proxy => {
-                    if (proxy.includes('@') || (proxy.includes('://') && !proxy.match(/^(http|https|socks5):\/\/[^@]+:\d+$/))) {
-                        // 带认证信息或其他完整格式的代理放入完整代理列表
-                        fullProxies.push(proxy);
-                    } else if (proxy.startsWith('http://')) {
-                        // HTTP代理
-                        httpProxies.push(proxy.replace('http://', ''));
-                    } else if (proxy.startsWith('https://')) {
-                        // HTTPS代理
-                        httpsProxies.push(proxy.replace('https://', ''));
-                    } else if (proxy.startsWith('socks5://')) {
-                        // SOCKS5代理
-                        socks5Proxies.push(proxy.replace('socks5://', ''));
-                    } else {
-                        // 没有协议前缀的默认作为HTTP代理
-                        httpProxies.push(proxy);
-                    }
-                });
-                
-                // 更新各个文本框的内容
-                document.getElementById('http-proxy-list').value = httpProxies.join('\n');
-                document.getElementById('https-proxy-list').value = httpsProxies.join('\n');
-                document.getElementById('socks5-proxy-list').value = socks5Proxies.join('\n');
-                document.getElementById('full-proxy-list').value = fullProxies.join('\n');
+                proxyItems = (data.proxies || [])
+                    .map(line => (line || '').trim())
+                    .filter(line => line.length > 0)
+                    .map(line => ({
+                        enabled: !line.startsWith('#'),
+                        addr: normalizeProxyAddr(line)
+                    }))
+                    .filter(item => item.addr);
+                renderProxyItems();
             });
+        }
+
+        function renderProxyItems() {
+            const box = document.getElementById('proxy-items');
+            const empty = document.getElementById('proxy-empty');
+            if (!box) return;
+            box.innerHTML = '';
+            proxyItems.forEach((item, idx) => {
+                const proto = proxyProtocol(item.addr);
+                const row = document.createElement('div');
+                row.className = 'proxy-item' + (item.enabled ? '' : ' disabled');
+
+                const sw = document.createElement('label');
+                sw.className = 'proxy-switch';
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.checked = item.enabled;
+                cb.addEventListener('change', () => toggleProxy(idx));
+                const slider = document.createElement('span');
+                slider.className = 'proxy-slider';
+                sw.appendChild(cb);
+                sw.appendChild(slider);
+
+                const badge = document.createElement('span');
+                badge.className = 'proxy-proto proxy-proto-' + proto;
+                badge.textContent = proto.toUpperCase();
+
+                const addr = document.createElement('span');
+                addr.className = 'proxy-addr';
+                addr.textContent = item.addr;
+                addr.title = item.addr;
+
+                const del = document.createElement('button');
+                del.type = 'button';
+                del.className = 'proxy-del';
+                del.title = (translations[currentLanguage] && translations[currentLanguage].delete_btn) || '删除';
+                del.innerHTML = '<i class="fa fa-times"></i>';
+                del.addEventListener('click', () => deleteProxy(idx));
+
+                row.appendChild(sw);
+                row.appendChild(badge);
+                row.appendChild(addr);
+                row.appendChild(del);
+                box.appendChild(row);
+            });
+            if (empty) empty.style.display = proxyItems.length ? 'none' : 'block';
+            updateProxyCount();
+        }
+
+        function updateProxyCount() {
+            const total = document.getElementById('proxy-total');
+            const enabled = document.getElementById('proxy-enabled-count');
+            if (total) total.textContent = proxyItems.length;
+            if (enabled) enabled.textContent = proxyItems.filter(x => x.enabled).length;
+        }
+
+        function toggleProxy(idx) {
+            if (!proxyItems[idx]) return;
+            proxyItems[idx].enabled = !proxyItems[idx].enabled;
+            renderProxyItems();
+        }
+
+        function deleteProxy(idx) {
+            proxyItems.splice(idx, 1);
+            renderProxyItems();
+        }
+
+        function setAllProxies(enabled) {
+            proxyItems.forEach(x => x.enabled = enabled);
+            renderProxyItems();
+        }
+
+        function addProxies() {
+            const ta = document.getElementById('proxy-add-input');
+            if (!ta) return;
+            const lines = ta.value.split('\n').map(s => s.trim()).filter(Boolean);
+            let added = 0;
+            lines.forEach(line => {
+                const enabled = !line.startsWith('#');
+                const addr = normalizeProxyAddr(line);
+                if (!addr) return;
+                if (proxyItems.some(x => x.addr === addr)) return; // 去重，避免重复添加
+                proxyItems.push({ addr, enabled });
+                added++;
+            });
+            ta.value = '';
+            renderProxyItems();
+            if (added > 0) {
+                showNotification(((translations[currentLanguage] && translations[currentLanguage].proxy_added) || '已添加 {} 个代理').replace('{}', added), 'success');
+            } else {
+                showNotification((translations[currentLanguage] && translations[currentLanguage].proxy_add_none) || '没有可添加的新代理', 'info');
+            }
         }
 
         function loadIpLists() {
@@ -1823,29 +1899,9 @@
         }
 
         function saveProxies() {
-            // 获取各个代理列表的内容
-            const httpProxies = document.getElementById('http-proxy-list').value
-                .split('\n')
-                .filter(line => line.trim())
-                .map(line => `http://${line.trim()}`);
-            
-            const httpsProxies = document.getElementById('https-proxy-list').value
-                .split('\n')
-                .filter(line => line.trim())
-                .map(line => `https://${line.trim()}`);
-            
-            const socks5Proxies = document.getElementById('socks5-proxy-list').value
-                .split('\n')
-                .filter(line => line.trim())
-                .map(line => `socks5://${line.trim()}`);
-            
-            const fullProxies = document.getElementById('full-proxy-list').value
-                .split('\n')
-                .filter(line => line.trim());
-            
-            // 合并所有代理列表
-            const allProxies = [...httpProxies, ...httpsProxies, ...socks5Proxies, ...fullProxies];
-            
+            // 从统一列表构建；禁用项写为以 # 开头的注释行，后端加载时会跳过
+            const allProxies = proxyItems.map(item => item.enabled ? item.addr : '#' + item.addr);
+
             // 获取测试URL
             const testUrl = document.getElementById('test-target-url').value.trim();
             
@@ -2346,6 +2402,17 @@
                     'socks5': '每行一个地址，格式：ip:port\n例如：127.0.0.1:1080',
                     'full': '每行一个地址，格式：protocol://[username:password@]ip:port\n例如：http://user:pass@127.0.0.1:8080'
                 },
+                'proxy_total_label': '代理总数',
+                'proxy_enabled_label': '已启用',
+                'proxy_disabled_label': '已禁用',
+                'enable_all_btn': '全部启用',
+                'disable_all_btn': '全部禁用',
+                'add_proxy_btn': '添加代理',
+                'delete_btn': '删除',
+                'proxy_empty_hint': '暂无代理，请在下方添加',
+                'proxy_add_placeholder': '每行一个：ip:port 或 protocol://[user:pass@]ip:port\n例如：http://user:pass@127.0.0.1:8080',
+                'proxy_added': '已添加 {} 个代理',
+                'proxy_add_none': '没有可添加的新代理',
                 'save_proxy_btn': '保存代理',
                 'check_proxy_btn': '检测代理',
                 'checking_proxy': '检测中...',
@@ -2554,6 +2621,17 @@
                     'socks5': 'One address per line, format: ip:port\nExample: 127.0.0.1:1080',
                     'full': 'One address per line, format: protocol://[username:password@]ip:port\nExample: http://user:pass@127.0.0.1:8080'
                 },
+                'proxy_total_label': 'Total',
+                'proxy_enabled_label': 'Enabled',
+                'proxy_disabled_label': 'Disabled',
+                'enable_all_btn': 'Enable All',
+                'disable_all_btn': 'Disable All',
+                'add_proxy_btn': 'Add Proxy',
+                'delete_btn': 'Delete',
+                'proxy_empty_hint': 'No proxies yet. Add some below.',
+                'proxy_add_placeholder': 'One per line: ip:port or protocol://[user:pass@]ip:port\nExample: http://user:pass@127.0.0.1:8080',
+                'proxy_added': 'Added {} proxy(ies)',
+                'proxy_add_none': 'No new proxies to add',
                 'save_proxy_btn': 'Save Proxies',
                 'check_proxy_btn': 'Check Proxies',
                 'checking_proxy': 'Checking...',
@@ -2592,44 +2670,8 @@
             // 更新日志级别选项
             updateLogLevelOptions();
 
-            // 更新代理列表标题
-            const proxyHeaders = document.querySelectorAll('.proxy-list-header span');
-            proxyHeaders.forEach(header => {
-                const headerText = header.textContent.toLowerCase();
-                if (headerText.includes('http') && !headerText.includes('https')) {
-                    header.textContent = translations[language].http_proxy;
-                } else if (headerText.includes('https')) {
-                    header.textContent = translations[language].https_proxy;
-                } else if (headerText.includes('socks5')) {
-                    header.textContent = translations[language].socks5_proxy;
-                }
-            });
-
-            // 更新代理列表占位符
-            document.getElementById('http-proxy-list').setAttribute('placeholder', translations[language].proxy_placeholder.http);
-            document.getElementById('https-proxy-list').setAttribute('placeholder', translations[language].proxy_placeholder.https);
-            document.getElementById('socks5-proxy-list').setAttribute('placeholder', translations[language].proxy_placeholder.socks5);
-            
-            // 更新帮助文本
-            const helpText = document.querySelector('.proxy-list-help');
-            if (helpText) {
-                helpText.textContent = translations[language].proxy_help;
-            }
-
-            // 更新占位符文本
-            const placeholders = {
-                'http-proxy-list': translations[language].proxy_placeholder.http,
-                'https-proxy-list': translations[language].proxy_placeholder.https,
-                'socks5-proxy-list': translations[language].proxy_placeholder.socks5,
-                'full-proxy-list': translations[language].proxy_placeholder.full
-            };
-
-            Object.entries(placeholders).forEach(([id, text]) => {
-                const element = document.getElementById(id);
-                if (element) {
-                    element.setAttribute('placeholder', text);
-                }
-            });
+            // 语言切换后刷新代理列表，更新删除按钮等提示文案
+            renderProxyItems();
 
             // 更新按钮文本
             const saveBtn = document.querySelector('.proxy-actions .btn-primary span');

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1863,6 +1863,17 @@
         // ===== 代理管理：启用/禁用列表 =====
         // 单一数据源：每项 { addr, enabled, selected }
         let proxyItems = [];
+        // 多浏览器共享检测状态
+        let lastProxyCheckLogId = 0;
+        let lastProxyCheckLogClearId = 0;
+        let lastProxyCheckRevision = 0;
+        let proxyCheckSyncTimer = null;
+        // 本页刚写入、尚未拿到服务端 id 的日志指纹，避免轮询重复插入
+        const pendingLocalCheckLogs = new Set();
+
+        function proxyCheckLogFingerprint(message, level) {
+            return `${level || 'info'}|${message || ''}`;
+        }
 
         // 协议别名 → 引擎标准协议（与后端 modules.PROXY_SCHEME_ALIASES 对齐）
         const PROXY_SCHEME_ALIASES = {
@@ -1958,7 +1969,7 @@
 
         function loadProxies() {
             $.get(appendToken('/api/proxies'), function(data) {
-                // 保留已有检测状态（按地址）
+                // 保留已有检测状态（按地址）；服务端结果优先用于跨浏览器恢复
                 const prevStatus = {};
                 proxyItems.forEach(item => {
                     if (item.addr && item.checkStatus) {
@@ -1968,17 +1979,28 @@
                         };
                     }
                 });
+                const serverResults = data.check_results || {};
                 proxyItems = (data.proxies || [])
                     .map(line => (line || '').trim())
                     .filter(line => line.length > 0)
                     .map(line => {
                         const addr = normalizeProxyAddr(line);
+                        const server = serverResults[addr];
+                        let checkStatus = prevStatus[addr] ? prevStatus[addr].status : null;
+                        let checkLatency = prevStatus[addr] ? prevStatus[addr].latency : null;
+                        if (server && server.status) {
+                            // 本地正在 testing 时不覆盖，避免闪烁
+                            if (checkStatus !== 'testing') {
+                                checkStatus = server.status;
+                                checkLatency = server.valid ? Number(server.elapsed_ms) : null;
+                            }
+                        }
                         return {
                             enabled: !line.startsWith('#'),
                             selected: false,
                             addr,
-                            checkStatus: prevStatus[addr] ? prevStatus[addr].status : null, // null | testing | ok | fail
-                            checkLatency: prevStatus[addr] ? prevStatus[addr].latency : null
+                            checkStatus, // null | testing | ok | fail
+                            checkLatency
                         };
                     })
                     .filter(item => item.addr);
@@ -2114,27 +2136,135 @@
             return ((el && el.value) || '').trim() || 'https://www.baidu.com';
         }
 
-        function appendProxyCheckLog(message, level) {
+        function applyServerCheckResults(results) {
+            if (!results || typeof results !== 'object') return false;
+            let changed = false;
+            proxyItems.forEach((item, idx) => {
+                if (!item || !item.addr) return;
+                // 本页正在测这一条时，不拿远端结果打断本地 testing 态
+                if (item.checkStatus === 'testing') return;
+                const remote = results[item.addr];
+                if (!remote || !remote.status) return;
+                const nextStatus = remote.status === 'ok' ? 'ok' : 'fail';
+                const nextLatency = nextStatus === 'ok' && remote.elapsed_ms != null
+                    ? Number(remote.elapsed_ms)
+                    : null;
+                if (item.checkStatus !== nextStatus || item.checkLatency !== nextLatency) {
+                    item.checkStatus = nextStatus;
+                    item.checkLatency = nextLatency;
+                    updateProxyTestButton(idx);
+                    changed = true;
+                }
+            });
+            return changed;
+        }
+
+        function appendProxyCheckLog(message, level, options = {}) {
             const box = document.getElementById('proxy-check-log');
             if (!box) return;
+            const { sync = true, time = null, id = null } = options;
             if (box.dataset.empty === '1' || box.querySelector('.proxy-check-log-placeholder')) {
                 box.innerHTML = '';
                 box.dataset.empty = '0';
             }
-            const time = new Date().toLocaleTimeString();
+            const displayTime = time || new Date().toLocaleTimeString();
             const line = document.createElement('div');
             line.className = 'proxy-check-log-line' + (level ? ' is-' + level : '');
-            line.innerHTML = `<span class="proxy-check-log-time">${time}</span><span class="proxy-check-log-msg"></span>`;
+            if (id != null) line.dataset.logId = String(id);
+            line.innerHTML = `<span class="proxy-check-log-time"></span><span class="proxy-check-log-msg"></span>`;
+            line.querySelector('.proxy-check-log-time').textContent = displayTime;
             line.querySelector('.proxy-check-log-msg').textContent = message;
             box.appendChild(line);
             box.scrollTop = box.scrollHeight;
+
+            if (id != null) {
+                lastProxyCheckLogId = Math.max(lastProxyCheckLogId, Number(id) || 0);
+            }
+
+            // 推到服务端，其他浏览器可轮询到
+            if (sync) {
+                const fp = proxyCheckLogFingerprint(message, level);
+                pendingLocalCheckLogs.add(fp);
+                $.ajax({
+                    url: appendToken('/api/proxy_check_logs'),
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify({ message: message, level: level || 'info' })
+                }).done(function(data) {
+                    if (data && data.id != null) {
+                        lastProxyCheckLogId = Math.max(lastProxyCheckLogId, Number(data.id) || 0);
+                        line.dataset.logId = String(data.id);
+                    }
+                }).always(function() {
+                    pendingLocalCheckLogs.delete(fp);
+                });
+            }
         }
 
-        function clearProxyCheckLog() {
+        function clearProxyCheckLog(options = {}) {
+            const { sync = true } = options;
             const box = document.getElementById('proxy-check-log');
             if (!box) return;
             box.innerHTML = `<div class="proxy-check-log-placeholder">${tProxy('proxy_check_log_empty', '暂无检测记录')}</div>`;
             box.dataset.empty = '1';
+            pendingLocalCheckLogs.clear();
+            if (sync) {
+                $.ajax({
+                    url: appendToken('/api/proxy_check_logs'),
+                    method: 'DELETE'
+                }).done(function(data) {
+                    if (data && data.log_clear_id != null) {
+                        lastProxyCheckLogClearId = Number(data.log_clear_id) || lastProxyCheckLogClearId;
+                    }
+                });
+            }
+        }
+
+        function applyServerCheckLogs(logs, logClearId, latestLogId) {
+            if (logClearId != null && Number(logClearId) > lastProxyCheckLogClearId) {
+                lastProxyCheckLogClearId = Number(logClearId);
+                // 远端清空：仅本地清空显示，不再回写服务端
+                clearProxyCheckLog({ sync: false });
+            }
+            if (!Array.isArray(logs) || !logs.length) {
+                if (latestLogId != null) {
+                    lastProxyCheckLogId = Math.max(lastProxyCheckLogId, Number(latestLogId) || 0);
+                }
+                return;
+            }
+            logs.forEach(entry => {
+                if (!entry || entry.id == null) return;
+                const id = Number(entry.id) || 0;
+                if (id <= lastProxyCheckLogId) return;
+                const fp = proxyCheckLogFingerprint(entry.message || '', entry.level || 'info');
+                // 本页刚写过的同一条：只推进游标，避免重复显示
+                if (pendingLocalCheckLogs.has(fp)) {
+                    lastProxyCheckLogId = Math.max(lastProxyCheckLogId, id);
+                    pendingLocalCheckLogs.delete(fp);
+                    return;
+                }
+                appendProxyCheckLog(entry.message || '', entry.level || 'info', {
+                    sync: false,
+                    time: entry.time || null,
+                    id: id
+                });
+            });
+            if (latestLogId != null) {
+                lastProxyCheckLogId = Math.max(lastProxyCheckLogId, Number(latestLogId) || 0);
+            }
+        }
+
+        function syncProxyCheckState(options = {}) {
+            const { full = false } = options;
+            const since = full ? 0 : lastProxyCheckLogId;
+            return $.get(appendToken(`/api/proxy_check_state?since_log_id=${since}`), function(data) {
+                if (!data || data.status !== 'success') return;
+                if (data.revision != null) {
+                    lastProxyCheckRevision = Number(data.revision) || lastProxyCheckRevision;
+                }
+                applyServerCheckResults(data.results || {});
+                applyServerCheckLogs(data.logs || [], data.log_clear_id, data.latest_log_id);
+            });
         }
 
         function requestCheckProxy(addr, testUrl) {
@@ -3591,10 +3721,13 @@
         loadConfig();
         loadProxies();
         loadIpLists();
-        
-        setInterval(updateStatus, 2000); 
-        setInterval(updateCountdown, 1000); 
+        // 首次全量拉取共享检测状态，之后增量轮询
+        syncProxyCheckState({ full: true });
+
+        setInterval(updateStatus, 2000);
+        setInterval(updateCountdown, 1000);
         setInterval(updateLogs, 2000);
+        setInterval(function() { syncProxyCheckState(); }, 2000);
         updateStatus();
         updateCountdown();
         updateLogs();

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1485,6 +1485,30 @@
                                 <input type="text" class="form-control" id="test-target-url" placeholder="https://www.baidu.com">
                                 <div class="form-text" data-i18n="test_url_help">用于检测代理有效性的目标地址</div>
                             </div>
+                            <div class="proxy-health-settings">
+                                <div class="proxy-health-field">
+                                    <label class="form-label" for="proxy-check-timeout" data-i18n="proxy_check_timeout_label">检测超时（ms）</label>
+                                    <input type="number" class="form-control" id="proxy-check-timeout" min="200" max="60000" step="100" value="2000" onchange="saveHealthCheckConfig()">
+                                </div>
+                                <div class="proxy-health-toggle">
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" id="auto-check-enabled" onchange="toggleAutoCheckControls(); saveHealthCheckConfig()">
+                                        <label class="form-check-label" for="auto-check-enabled" data-i18n="auto_check_enabled_label">启用自动检测</label>
+                                    </div>
+                                </div>
+                                <div class="proxy-health-field">
+                                    <label class="form-label" for="auto-check-interval" data-i18n="auto_check_interval_label">自动检测周期（分钟）</label>
+                                    <input type="number" class="form-control" id="auto-check-interval" min="1" max="10080" step="1" value="60" disabled onchange="saveHealthCheckConfig()">
+                                </div>
+                                <div class="proxy-health-toggle">
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" id="auto-disable-failed" onchange="saveHealthCheckConfig()">
+                                        <label class="form-check-label" for="auto-disable-failed" data-i18n="auto_disable_failed_label">自动禁用失败代理</label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="form-text proxy-health-help" data-i18n="auto_disable_failed_help">启用后，手动或自动检测中超时、连接失败的代理会被禁用。</div>
+                            <div id="auto-check-status" class="proxy-auto-check-status"></div>
                             <div class="proxy-actions">
                                 <button class="btn btn-warning" id="check-proxy-btn" onclick="checkProxies('enabled')">
                                     <i class="fa fa-check-circle"></i>
@@ -1711,6 +1735,7 @@
 
                 // 更新按钮状态
                 updateServiceButtons(status);
+                updateAutoCheckStatus(data.auto_check);
             });
         }
 
@@ -1756,7 +1781,14 @@
                     $('input[name="blacklist_file"]').val(config.blacklist_file || '');
                     $('select[name="ip_auth_priority"]').val(config.ip_auth_priority || 'whitelist');
                     $('select[name="display_level"]').val(config.display_level || '1');
-                    
+                    $('#test-target-url').val(config.test_url || 'https://www.baidu.com');
+                    $('#proxy-check-timeout').val(config.proxy_check_timeout_ms || '2000');
+                    $('#auto-check-enabled').prop('checked', (config.auto_check_enabled || '').toLowerCase() === 'true');
+                    $('#auto-check-interval').val(config.auto_check_interval_minutes || '60');
+                    $('#auto-disable-failed').prop('checked', (config.auto_disable_failed_proxies || '').toLowerCase() === 'true');
+                    toggleAutoCheckControls();
+                    updateAutoCheckStatus(data.auto_check);
+
                     // 根据 use_getip 的状态更新 getip_url 输入框的禁用状态
                     const useGetip = (config.use_getip || '').toLowerCase() === 'true';
                     $('input[name="getip_url"]').prop('disabled', !useGetip);
@@ -1767,6 +1799,64 @@
                     // 更新地址显示
                     updateAddresses(config);
                 }
+            });
+        }
+
+        function toggleAutoCheckControls() {
+            const enabled = $('#auto-check-enabled').prop('checked');
+            $('#auto-check-interval').prop('disabled', !enabled);
+        }
+
+        function updateAutoCheckStatus(autoCheck) {
+            const box = document.getElementById('auto-check-status');
+            if (!box) return;
+            if (!autoCheck || !autoCheck.enabled) {
+                box.textContent = tProxy('auto_check_status_disabled', '自动检测未启用');
+                return;
+            }
+            const summary = autoCheck.summary;
+            let text = tProxy('auto_check_status_enabled', '自动检测已启用，每 {} 分钟执行一次')
+                .replace('{}', autoCheck.interval_minutes || 60);
+            if (summary) {
+                text += ' · ' + tProxy('auto_check_status_summary', '上次：成功 {} / 失败 {} / 禁用 {}')
+                    .replace('{}', summary.valid || 0)
+                    .replace('{}', summary.failed || 0)
+                    .replace('{}', summary.disabled || 0);
+            }
+            box.textContent = text;
+        }
+
+        function saveHealthCheckConfig() {
+            const timeout = Number($('#proxy-check-timeout').val());
+            const interval = Number($('#auto-check-interval').val());
+            if (!Number.isFinite(timeout) || timeout < 200 || timeout > 60000) {
+                showNotification(tProxy('proxy_check_timeout_invalid', '检测超时应在 200 到 60000 ms 之间'), 'error');
+                return;
+            }
+            if (!Number.isFinite(interval) || interval < 1 || interval > 10080) {
+                showNotification(tProxy('auto_check_interval_invalid', '自动检测周期应在 1 到 10080 分钟之间'), 'error');
+                return;
+            }
+            $.ajax({
+                url: appendToken('/api/config'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    test_url: getProxyTestUrl(),
+                    proxy_check_timeout_ms: timeout,
+                    auto_check_enabled: $('#auto-check-enabled').prop('checked'),
+                    auto_check_interval_minutes: interval,
+                    auto_disable_failed_proxies: $('#auto-disable-failed').prop('checked')
+                })
+            }).done(function(response) {
+                if (response.status === 'success') {
+                    showNotification(tProxy('health_check_config_saved', '检测设置已保存'), 'success');
+                    updateStatus();
+                } else {
+                    showNotification(response.message || tProxy('config_save_failed', '配置保存失败'), 'error');
+                }
+            }).fail(function(xhr) {
+                showNotification((xhr.responseJSON && xhr.responseJSON.message) || tProxy('config_save_failed', '配置保存失败'), 'error');
             });
         }
 
@@ -2067,6 +2157,33 @@
             });
         }
 
+        function autoDisableFailedProxies(addresses) {
+            if (!$('#auto-disable-failed').prop('checked') || !addresses.length) return;
+            $.ajax({
+                url: appendToken('/api/disable_proxies'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ proxies: addresses })
+            }).done(function(data) {
+                if (data.status === 'success' && data.disabled) {
+                    addresses.forEach(addr => {
+                        const item = proxyItems.find(x => x.addr === addr);
+                        if (item) item.enabled = false;
+                    });
+                    renderProxyItems();
+                    appendProxyCheckLog(
+                        tProxy('auto_disable_log', '已自动禁用 {} 个失败代理').replace('{}', data.disabled),
+                        'info'
+                    );
+                }
+            }).fail(function(xhr) {
+                appendProxyCheckLog(
+                    tProxy('auto_disable_failed_log', '自动禁用失败：{}').replace('{}', (xhr.responseJSON && xhr.responseJSON.message) || xhr.responseText || ''),
+                    'fail'
+                );
+            });
+        }
+
         function formatCheckResultLog(addr, data, ok) {
             const ms = (data && data.elapsed_ms != null) ? ` [${data.elapsed_ms}ms]` : '';
             const err = (!ok && data && data.error) ? ` — ${data.error}` : '';
@@ -2099,6 +2216,7 @@
                     const ok = applyProxyCheckResult(item, data);
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
+                    if (!ok) autoDisableFailedProxies([item.addr]);
                 })
                 .fail(function(xhr) {
                     item.checkStatus = 'fail';
@@ -2280,6 +2398,7 @@
             appendProxyCheckLog(startMsg.replace('{}', items.length), 'info');
 
             let stopped = false;
+            const failedAddresses = [];
 
             for (let i = 0; i < items.length; i++) {
                 if (proxyCheckCtl.stopRequested) {
@@ -2318,6 +2437,7 @@
                         // 停止时若请求已返回，仍记录结果
                         const ok = applyProxyCheckResult(item, data);
                         if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
+                        if (!ok) failedAddresses.push(item.addr);
                         updateProxyTestButton(idx);
                         appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
                         proxyCheckCtl.done++;
@@ -2326,6 +2446,7 @@
                     }
                     const ok = applyProxyCheckResult(item, data);
                     if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
+                    if (!ok) failedAddresses.push(item.addr);
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
                 } catch (e) {
@@ -2345,6 +2466,7 @@
                     }
                     item.checkStatus = 'fail';
                     item.checkLatency = null;
+                    failedAddresses.push(item.addr);
                     proxyCheckCtl.failCount++;
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(
@@ -2356,6 +2478,10 @@
 
                 proxyCheckCtl.done++;
                 updateCheckProgress();
+            }
+
+            if (failedAddresses.length) {
+                autoDisableFailedProxies([...new Set(failedAddresses)]);
             }
 
             const okCount = proxyCheckCtl.okCount;
@@ -2721,7 +2847,11 @@
                 blacklist_file: $('input[name="blacklist_file"]').val(),
                 ip_auth_priority: $('select[name="ip_auth_priority"]').val(),
                 display_level: $('select[name="display_level"]').val(),
-                test_url: $('input[name="test_url"]').val()
+                test_url: $('#test-target-url').val(),
+                proxy_check_timeout_ms: $('#proxy-check-timeout').val(),
+                auto_check_enabled: $('#auto-check-enabled').prop('checked').toString(),
+                auto_check_interval_minutes: $('#auto-check-interval').val(),
+                auto_disable_failed_proxies: $('#auto-disable-failed').prop('checked').toString()
             };
 
             // 保存配置
@@ -3045,6 +3175,19 @@
                 'check_progress_text': '进度 {}/{}（成功 {} / 失败 {}）',
                 'check_busy': '批量检测进行中，请先暂停/停止',
                 'proxy_test_btn': '测试连通性',
+                'proxy_check_timeout_label': '检测超时（ms）',
+                'proxy_check_timeout_invalid': '检测超时应在 200 到 60000 ms 之间',
+                'auto_check_enabled_label': '启用自动检测',
+                'auto_check_interval_label': '自动检测周期（分钟）',
+                'auto_check_interval_invalid': '自动检测周期应在 1 到 10080 分钟之间',
+                'auto_disable_failed_label': '自动禁用失败代理',
+                'auto_disable_failed_help': '启用后，手动或自动检测中超时、连接失败的代理会被禁用。',
+                'auto_check_status_disabled': '自动检测未启用',
+                'auto_check_status_enabled': '自动检测已启用，每 {} 分钟执行一次',
+                'auto_check_status_summary': '上次：成功 {} / 失败 {} / 禁用 {}',
+                'health_check_config_saved': '检测设置已保存',
+                'auto_disable_log': '已自动禁用 {} 个失败代理',
+                'auto_disable_failed_log': '自动禁用失败：{}',
                 'proxy_check_log_title': '检测日志',
                 'clear_check_log_btn': '清空',
                 'proxy_check_log_empty': '暂无检测记录',
@@ -3300,6 +3443,19 @@
                 'check_progress_text': 'Progress {}/{} (OK {} / FAIL {})',
                 'check_busy': 'Bulk check in progress — pause/stop first',
                 'proxy_test_btn': 'Test connectivity',
+                'proxy_check_timeout_label': 'Check timeout (ms)',
+                'proxy_check_timeout_invalid': 'Check timeout must be between 200 and 60000 ms',
+                'auto_check_enabled_label': 'Enable automatic checks',
+                'auto_check_interval_label': 'Auto-check interval (minutes)',
+                'auto_check_interval_invalid': 'Auto-check interval must be between 1 and 10080 minutes',
+                'auto_disable_failed_label': 'Automatically disable failed proxies',
+                'auto_disable_failed_help': 'When enabled, proxies that time out or fail during manual or automatic checks are disabled.',
+                'auto_check_status_disabled': 'Automatic checks are disabled',
+                'auto_check_status_enabled': 'Automatic checks are enabled every {} minute(s)',
+                'auto_check_status_summary': 'Last run: OK {} / FAIL {} / disabled {}',
+                'health_check_config_saved': 'Check settings saved',
+                'auto_disable_log': 'Automatically disabled {} failed proxy(ies)',
+                'auto_disable_failed_log': 'Automatic disable failed: {}',
                 'proxy_check_log_title': 'Check Log',
                 'clear_check_log_btn': 'Clear',
                 'proxy_check_log_empty': 'No check records yet',
@@ -3377,6 +3533,7 @@
                 
                 // 更新按钮状态
                 updateServiceButtons(status);
+                updateAutoCheckStatus(data.auto_check);
                 
                 // 确保在DOM加载完成后更新
                 if (document.readyState === 'loading') {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1871,7 +1871,12 @@
                 // 保留已有检测状态（按地址）
                 const prevStatus = {};
                 proxyItems.forEach(item => {
-                    if (item.addr && item.checkStatus) prevStatus[item.addr] = item.checkStatus;
+                    if (item.addr && item.checkStatus) {
+                        prevStatus[item.addr] = {
+                            status: item.checkStatus,
+                            latency: item.checkLatency
+                        };
+                    }
                 });
                 proxyItems = (data.proxies || [])
                     .map(line => (line || '').trim())
@@ -1882,7 +1887,8 @@
                             enabled: !line.startsWith('#'),
                             selected: false,
                             addr,
-                            checkStatus: prevStatus[addr] || null // null | testing | ok | fail
+                            checkStatus: prevStatus[addr] ? prevStatus[addr].status : null, // null | testing | ok | fail
+                            checkLatency: prevStatus[addr] ? prevStatus[addr].latency : null
                         };
                     })
                     .filter(item => item.addr);
@@ -1940,7 +1946,9 @@
                     testBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
                     testBtn.disabled = true;
                 } else if (item.checkStatus === 'ok') {
-                    testBtn.innerHTML = '<i class="fa fa-check"></i>';
+                    testBtn.classList.add(latencyClass(item.checkLatency));
+                    testBtn.textContent = formatLatency(item.checkLatency);
+                    testBtn.title = `${tProxy('proxy_test_btn', '测试连通性')} · ${formatLatency(item.checkLatency)}`;
                 } else if (item.checkStatus === 'fail') {
                     testBtn.innerHTML = '<i class="fa fa-times"></i>';
                 } else {
@@ -1967,6 +1975,26 @@
             updateProxyCount();
         }
 
+        function formatLatency(latency) {
+            const value = Number(latency);
+            return Number.isFinite(value) && value >= 0 ? `${Math.round(value)}ms` : '--';
+        }
+
+        function latencyClass(latency) {
+            const value = Number(latency);
+            if (!Number.isFinite(value) || value < 0) return 'is-latency-unknown';
+            if (value < 500) return 'is-latency-fast';
+            if (value < 1500) return 'is-latency-medium';
+            return 'is-latency-slow';
+        }
+
+        function applyProxyCheckResult(item, data) {
+            const ok = !!(data && data.status === 'success' && data.valid);
+            item.checkStatus = ok ? 'ok' : 'fail';
+            item.checkLatency = ok && data.elapsed_ms != null ? Number(data.elapsed_ms) : null;
+            return ok;
+        }
+
         function updateProxyTestButton(idx) {
             const item = proxyItems[idx];
             if (!item) return;
@@ -1981,7 +2009,9 @@
             if (item.checkStatus === 'testing') {
                 btn.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
             } else if (item.checkStatus === 'ok') {
-                btn.innerHTML = '<i class="fa fa-check"></i>';
+                btn.classList.add(latencyClass(item.checkLatency));
+                btn.textContent = formatLatency(item.checkLatency);
+                btn.title = `${tProxy('proxy_test_btn', '测试连通性')} · ${formatLatency(item.checkLatency)}`;
             } else if (item.checkStatus === 'fail') {
                 btn.innerHTML = '<i class="fa fa-times"></i>';
             } else {
@@ -2057,6 +2087,7 @@
 
             const testUrl = getProxyTestUrl();
             item.checkStatus = 'testing';
+            item.checkLatency = null;
             updateProxyTestButton(idx);
             appendProxyCheckLog(
                 tProxy('proxy_check_item_testing', '检测中：{}').replace('{}', item.addr),
@@ -2065,13 +2096,13 @@
 
             requestCheckProxy(item.addr, testUrl)
                 .done(function(data) {
-                    const ok = !!(data && data.status === 'success' && data.valid);
-                    item.checkStatus = ok ? 'ok' : 'fail';
+                    const ok = applyProxyCheckResult(item, data);
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
                 })
                 .fail(function(xhr) {
                     item.checkStatus = 'fail';
+                    item.checkLatency = null;
                     updateProxyTestButton(idx);
                     let err = '';
                     try {
@@ -2272,6 +2303,7 @@
                 const item = proxyItems[idx];
 
                 item.checkStatus = 'testing';
+                item.checkLatency = null;
                 updateProxyTestButton(idx);
                 appendProxyCheckLog(
                     tProxy('proxy_check_item_testing', '检测中：{}').replace('{}', item.addr)
@@ -2284,8 +2316,7 @@
                     const data = await requestCheckProxy(item.addr, testUrl);
                     if (proxyCheckCtl.stopRequested) {
                         // 停止时若请求已返回，仍记录结果
-                        const ok = !!(data && data.status === 'success' && data.valid);
-                        item.checkStatus = ok ? 'ok' : 'fail';
+                        const ok = applyProxyCheckResult(item, data);
                         if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
                         updateProxyTestButton(idx);
                         appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
@@ -2293,8 +2324,7 @@
                         stopped = true;
                         break;
                     }
-                    const ok = !!(data && data.status === 'success' && data.valid);
-                    item.checkStatus = ok ? 'ok' : 'fail';
+                    const ok = applyProxyCheckResult(item, data);
                     if (ok) proxyCheckCtl.okCount++; else proxyCheckCtl.failCount++;
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(formatCheckResultLog(item.addr, data, ok), ok ? 'ok' : 'fail');
@@ -2304,6 +2334,7 @@
                     if (aborted) {
                         // 当前条被中止：恢复为未检测，不计入失败
                         item.checkStatus = null;
+                        item.checkLatency = null;
                         updateProxyTestButton(idx);
                         appendProxyCheckLog(
                             tProxy('check_item_aborted', '已中止：{}').replace('{}', item.addr),
@@ -2313,6 +2344,7 @@
                         break;
                     }
                     item.checkStatus = 'fail';
+                    item.checkLatency = null;
                     proxyCheckCtl.failCount++;
                     updateProxyTestButton(idx);
                     appendProxyCheckLog(


### PR DESCRIPTION
- 暗色模式下补齐 placeholder/caret 颜色并提亮文字，修复代理管理输入框 占位提示几乎不可见的问题；聚焦时背景改为变亮而非变暗
- 代理管理由 4 个文本框改为带开关的统一列表：支持逐条启用/禁用、删除、 批量添加，无协议前缀的 ip:port 自动补全为 http://，禁用项存为 # 注释行
- 后端 _load_file_proxies 跳过以 # 开头的行，禁用的代理不参与轮换